### PR TITLE
Cleanup

### DIFF
--- a/spot-contracts/.openzeppelin/goerli.json
+++ b/spot-contracts/.openzeppelin/goerli.json
@@ -172,7 +172,7 @@
             "src": "contracts/PerpetualTranche.sol:219"
           },
           {
-            "label": "minTrancheMaturiySec",
+            "label": "minTrancheMaturitySec",
             "offset": 0,
             "slot": "156",
             "type": "t_uint256",
@@ -180,7 +180,7 @@
             "src": "contracts/PerpetualTranche.sol:223"
           },
           {
-            "label": "maxTrancheMaturiySec",
+            "label": "maxTrancheMaturitySec",
             "offset": 0,
             "slot": "157",
             "type": "t_uint256",
@@ -517,7 +517,7 @@
             "src": "contracts/PerpetualTranche.sol:219"
           },
           {
-            "label": "minTrancheMaturiySec",
+            "label": "minTrancheMaturitySec",
             "offset": 0,
             "slot": "156",
             "type": "t_uint256",
@@ -525,7 +525,7 @@
             "src": "contracts/PerpetualTranche.sol:223"
           },
           {
-            "label": "maxTrancheMaturiySec",
+            "label": "maxTrancheMaturitySec",
             "offset": 0,
             "slot": "157",
             "type": "t_uint256",
@@ -862,7 +862,7 @@
             "src": "contracts/PerpetualTranche.sol:220"
           },
           {
-            "label": "minTrancheMaturiySec",
+            "label": "minTrancheMaturitySec",
             "offset": 0,
             "slot": "156",
             "type": "t_uint256",
@@ -870,7 +870,7 @@
             "src": "contracts/PerpetualTranche.sol:224"
           },
           {
-            "label": "maxTrancheMaturiySec",
+            "label": "maxTrancheMaturitySec",
             "offset": 0,
             "slot": "157",
             "type": "t_uint256",

--- a/spot-contracts/contracts/_interfaces/IPerpetualTranche.sol
+++ b/spot-contracts/contracts/_interfaces/IPerpetualTranche.sol
@@ -33,7 +33,7 @@ interface IPerpetualTranche is IERC20Upgradeable {
     // @notice Event emitted when maturity tolerance parameters are updated.
     // @param min The minimum maturity time.
     // @param max The maximum maturity time.
-    event UpdatedTolerableTrancheMaturiy(uint256 min, uint256 max);
+    event UpdatedTolerableTrancheMaturity(uint256 min, uint256 max);
 
     // @notice Event emitted when the max total supply is updated.
     // @param maxSupply The max total supply.
@@ -138,9 +138,9 @@ interface IPerpetualTranche is IERC20Upgradeable {
     // @param token The address of a token to check.
     function inReserve(IERC20Upgradeable token) external returns (bool);
 
-    // @notice Fetches the reserve's token balance.
-    // @param token The address of the reserve token.
-    function getReserveBalance(IERC20Upgradeable token) external returns (uint256);
+    // @notice Fetches the reserve's tranche token balance.
+    // @param tranche The address of the tranche token held by the reserve.
+    function getReserveTrancheBalance(IERC20Upgradeable tranche) external returns (uint256);
 
     // @notice Computes the total value of all reserve assets.
     function getReserveValue() external returns (uint256);

--- a/spot-contracts/contracts/test/mocks/MockPerpetualTranche.sol
+++ b/spot-contracts/contracts/test/mocks/MockPerpetualTranche.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.15;
 import { MockERC20 } from "./MockERC20.sol";
 
 contract MockPerpetualTranche is MockERC20 {
-    uint256 private _reserveBalance;
+    uint256 private _reserveTrancheBalance;
     uint256 public matureTrancheBalance;
     address public collateral;
 
@@ -12,14 +12,14 @@ contract MockPerpetualTranche is MockERC20 {
         return address(this);
     }
 
-    function getReserveBalance(
+    function getReserveTrancheBalance(
         address /* token */
     ) public view returns (uint256) {
-        return _reserveBalance;
+        return _reserveTrancheBalance;
     }
 
-    function setReserveBalance(uint256 b) external {
-        _reserveBalance = b;
+    function setReserveTrancheBalance(uint256 b) external {
+        _reserveTrancheBalance = b;
     }
 
     function setMatureTrancheBalance(uint256 b) external {

--- a/spot-contracts/tasks/deploy/perp.ts
+++ b/spot-contracts/tasks/deploy/perp.ts
@@ -92,7 +92,7 @@ task("deploy:PerpetualTranche")
       yieldStrategy.address,
     );
     await initTx.wait();
-    await perp.updateTolerableTrancheMaturiy(minMatuirtySec, maxMatuirtySec);
+    await perp.updateTolerableTrancheMaturity(minMatuirtySec, maxMatuirtySec);
 
     await hre.run("verify:contract", {
       address: feeStrategy.address,

--- a/spot-contracts/tasks/ops/perp.ts
+++ b/spot-contracts/tasks/ops/perp.ts
@@ -26,12 +26,13 @@ task("ops:info")
 
     console.log("---------------------------------------------------------------");
     console.log("PerpetualTranche:", perp.address);
+    console.log("reserve:", await perp.reserve());
     console.log("collateralToken", collateralToken.address);
     console.log("feeStrategy:", feeStrategy.address);
     console.log("yieldStrategy:", yieldStrategy.address);
     console.log("feeToken:", await feeStrategy.feeToken());
     console.log("pricingStrategy:", pricingStrategy.address);
-    console.log(`maturityTolarance: [${await perp.minTrancheMaturiySec()}, ${await perp.maxTrancheMaturiySec()}]`);
+    console.log(`maturityTolarance: [${await perp.minTrancheMaturitySec()}, ${await perp.maxTrancheMaturitySec()}]`);
     console.log("depositBond:", depositBond.address);
     console.log("issued:", issued);
     console.log("TotalSupply:", utils.formatUnits(await perp.totalSupply(), perpDecimals));
@@ -51,7 +52,7 @@ task("ops:info")
     console.log("token\tbalance\tyield\tprice\tupForRollover");
     for (let i = 0; i < reserveCount; i++) {
       const tokenAddress = await perp.callStatic.getReserveAt(i);
-      const balance = await perp.callStatic.getReserveBalance(tokenAddress);
+      const balance = await perp.callStatic.getReserveTrancheBalance(tokenAddress);
       const yieldF = await perp.computeYield(tokenAddress);
       const price = await perp.computePrice(tokenAddress);
       console.log(
@@ -339,7 +340,7 @@ task("ops:trancheAndRollover")
     const rotationTokenBalances = [];
     for (let i = 0; i < reserveCount; i++) {
       const tranche = await hre.ethers.getContractAt("ITranche", await perp.callStatic.getReserveAt(i));
-      const balance = await perp.callStatic.getReserveBalance(tranche.address);
+      const balance = await perp.callStatic.getReserveTrancheBalance(tranche.address);
       reserveTokens.push(tranche);
       reserveTokenBalances.push(balance);
       if (upForRotation[i] !== constants.AddressZero && balance.gt(0)) {

--- a/spot-contracts/test/PerpetualTranche_burn.ts
+++ b/spot-contracts/test/PerpetualTranche_burn.ts
@@ -368,7 +368,7 @@ describe("PerpetualTranche", function () {
     describe("when reserve has more than one tranche", function () {
       let newRedemptionTranche: Contract, tx: Transaction;
       beforeEach(async function () {
-        await perp.updateTolerableTrancheMaturiy(1200, 3600);
+        await perp.updateTolerableTrancheMaturity(1200, 3600);
 
         await advancePerpQueue(perp, 1200);
 
@@ -391,9 +391,9 @@ describe("PerpetualTranche", function () {
         expect((await perp.callStatic.getStdTrancheBalances())[0]).to.eq(toFixedPtAmt("750"));
         expect(await perp.totalSupply()).to.eq(toFixedPtAmt("750"));
         expect((await perp.callStatic.getStdTrancheBalances())[1]).to.eq(toFixedPtAmt("0"));
-        expect(await perp.callStatic.getReserveBalance(collateralToken.address)).to.eq(toFixedPtAmt("0"));
-        expect(await perp.callStatic.getReserveBalance(initialDepositTranche.address)).to.eq(toFixedPtAmt("500"));
-        expect(await perp.callStatic.getReserveBalance(newRedemptionTranche.address)).to.eq(toFixedPtAmt("500"));
+        expect(await collateralToken.balanceOf(await perp.reserve())).to.eq(toFixedPtAmt("0"));
+        expect(await perp.callStatic.getReserveTrancheBalance(initialDepositTranche.address)).to.eq(toFixedPtAmt("500"));
+        expect(await perp.callStatic.getReserveTrancheBalance(newRedemptionTranche.address)).to.eq(toFixedPtAmt("500"));
 
         tx = perp.burn(toFixedPtAmt("375"));
         await tx;
@@ -443,7 +443,7 @@ describe("PerpetualTranche", function () {
     describe("when reserve has mature collateral and tranches", function () {
       let newRedemptionTranche: Contract, tx: Transaction;
       beforeEach(async function () {
-        await perp.updateTolerableTrancheMaturiy(1200, 3600);
+        await perp.updateTolerableTrancheMaturity(1200, 3600);
 
         await advancePerpQueue(perp, 1200);
 
@@ -515,7 +515,7 @@ describe("PerpetualTranche", function () {
     describe("when the collateralToken balance is over the tranche balance", function () {
       let newRedemptionTranche: Contract, tx: Transaction;
       beforeEach(async function () {
-        await perp.updateTolerableTrancheMaturiy(1200, 3600);
+        await perp.updateTolerableTrancheMaturity(1200, 3600);
 
         await advancePerpQueue(perp, 1200);
 
@@ -539,9 +539,9 @@ describe("PerpetualTranche", function () {
         expect((await perp.callStatic.getStdTrancheBalances())[0]).to.eq(toFixedPtAmt("750"));
         expect(await perp.totalSupply()).to.eq(toFixedPtAmt("750"));
         expect((await perp.callStatic.getStdTrancheBalances())[1]).to.eq(toFixedPtAmt("0"));
-        expect(await perp.callStatic.getReserveBalance(collateralToken.address)).to.eq(toFixedPtAmt("0"));
-        expect(await perp.callStatic.getReserveBalance(initialDepositTranche.address)).to.eq(toFixedPtAmt("500"));
-        expect(await perp.callStatic.getReserveBalance(newRedemptionTranche.address)).to.eq(toFixedPtAmt("500"));
+        expect(await collateralToken.balanceOf(await perp.reserve())).to.eq(toFixedPtAmt("0"));
+        expect(await perp.callStatic.getReserveTrancheBalance(initialDepositTranche.address)).to.eq(toFixedPtAmt("500"));
+        expect(await perp.callStatic.getReserveTrancheBalance(newRedemptionTranche.address)).to.eq(toFixedPtAmt("500"));
 
         await advancePerpQueue(perp, 2400);
         await rebase(collateralToken, rebaseOracle, +0.5);
@@ -592,7 +592,7 @@ describe("PerpetualTranche", function () {
     describe("when the collateralToken balance is over the tranche balance", function () {
       let newRedemptionTranche: Contract, tx: Transaction;
       beforeEach(async function () {
-        await perp.updateTolerableTrancheMaturiy(1200, 3600);
+        await perp.updateTolerableTrancheMaturity(1200, 3600);
 
         await advancePerpQueue(perp, 1200);
 
@@ -665,7 +665,7 @@ describe("PerpetualTranche", function () {
     describe("when reserve has only mature collateral", function () {
       let newRedemptionTranche: Contract, tx: Transaction;
       beforeEach(async function () {
-        await perp.updateTolerableTrancheMaturiy(1200, 3600);
+        await perp.updateTolerableTrancheMaturity(1200, 3600);
 
         await advancePerpQueue(perp, 1200);
 

--- a/spot-contracts/test/PerpetualTranche_rollover.ts
+++ b/spot-contracts/test/PerpetualTranche_rollover.ts
@@ -80,7 +80,7 @@ describe("PerpetualTranche", function () {
     await feeStrategy.setBurnFee(toFixedPtAmt("0"));
     await feeStrategy.setRolloverFee(toFixedPtAmt("0"));
 
-    await perp.updateTolerableTrancheMaturiy(1200, 10800);
+    await perp.updateTolerableTrancheMaturity(1200, 10800);
     await advancePerpQueue(perp, 10900);
 
     holdingPenBond = await bondAt(await perp.callStatic.getDepositBond());

--- a/spot-contracts/test/RouterV1.ts
+++ b/spot-contracts/test/RouterV1.ts
@@ -68,7 +68,7 @@ describe("RouterV1", function () {
         initializer: "init(string,string,address,address,address,address,address)",
       },
     );
-    await perp.updateTolerableTrancheMaturiy(600, 3600);
+    await perp.updateTolerableTrancheMaturity(600, 3600);
     await advancePerpQueue(perp, 3600);
 
     depositBond = await bondAt(await perp.callStatic.getDepositBond());

--- a/spot-contracts/test/helpers.ts
+++ b/spot-contracts/test/helpers.ts
@@ -179,7 +179,7 @@ export const advancePerpQueueToBondMaturity = async (perp: Contract, bond: Contr
 };
 
 export const advancePerpQueueToRollover = async (perp: Contract, bond: Contract): Promise<Transaction> => {
-  const bufferSec = await perp.minTrancheMaturiySec();
+  const bufferSec = await perp.minTrancheMaturitySec();
   const matuirtyDate = await bond.maturityDate();
   await TimeHelpers.setNextBlockTimestamp(matuirtyDate.sub(bufferSec).toNumber() + 1);
   return perp.updateState();
@@ -190,7 +190,7 @@ export const logReserveComposition = async (perp: Contract) => {
   console.log("Reserve count", count);
   for (let i = 0; i < count; i++) {
     const token = await perp.callStatic.getReserveAt(i);
-    console.log(i, token, await perp.callStatic.getReserveBalance(token));
+    console.log(i, token, await perp.callStatic.getReserveTrancheBalance(token));
   }
 };
 
@@ -201,7 +201,7 @@ export const checkReserveComposition = async (perp: Contract, tokens: Contract[]
     expect(await perp.callStatic.inReserve(tokens[i].address)).to.eq(true);
     expect(await perp.callStatic.getReserveAt(i)).to.eq(tokens[i].address);
     if (checkBalances) {
-      expect(await perp.callStatic.getReserveBalance(tokens[i].address)).to.eq(balances[i]);
+      expect(await tokens[i].balanceOf(perp.reserve())).to.eq(balances[i]);
     }
   }
   await expect(perp.callStatic.getReserveAt(tokens.length)).to.be.reverted;


### PR DESCRIPTION
* Using the `reserves` list to keep track of the collateral token too. reserves(0) always points to the collateral token which is setup on initialization.
* Using consistent more terminology while referring to the mature tranche.
* Removed unused `getReserveBalance` method. Downstream services can call `token.balanceOf(perp.reserve())` if they want the token balance. Replaced it with `getReserveTrancheBalance` method. Downstream services can now examine the state of each reserve asset  using `getReserveTrancheBalance(token) . computeYield(token) . computePrice(token) ` 
* Fixed typo "Maturiy" -> "Maturity"
* Emitting log events with initial values during perp contract initialization. 