### PR TITLE
Enforcing supply cap

### DIFF
--- a/spot-contracts/test/PerpetualTranche_burn.ts
+++ b/spot-contracts/test/PerpetualTranche_burn.ts
@@ -136,6 +136,18 @@ describe("PerpetualTranche", function () {
       });
     });
 
+    describe("when the supply cap is exceeded", function () {
+      beforeEach(async function () {
+        await feeStrategy.setBurnFee(toFixedPtAmt("-100"));
+        await perp.updateMintingLimits(toFixedPtAmt("100"), toFixedPtAmt("1"));
+      });
+
+      it("should revert", async function () {
+        await expect(perp.burn(toFixedPtAmt("0.01"))).to.revertedWith("ExceededMaxSupply");
+      });
+    });
+
+
     describe("when fee is in native token", function () {
       describe("when fee is zero", function () {
         it("should burn perp tokens", async function () {

--- a/spot-contracts/test/PerpetualTranche_rollover.ts
+++ b/spot-contracts/test/PerpetualTranche_rollover.ts
@@ -247,6 +247,20 @@ describe("PerpetualTranche", function () {
       });
     });
 
+    describe("when the supply cap is exceeded", function () {
+      beforeEach(async function () {
+        await feeStrategy.setRolloverFee(toFixedPtAmt("-100"));
+        await perp.updateMintingLimits(toFixedPtAmt("100"), toFixedPtAmt("1"));
+      });
+
+      it("should revert", async function () {
+        await expect(
+          perp.rollover(rolloverInTranche.address, reserveTranche1.address, toFixedPtAmt("100")),
+        ).to.revertedWith("ExceededMaxSupply");
+      });
+    });
+
+
     describe("when trancheIn yield is 0.5", function () {
       let newRotationInTranche: Contract;
       beforeEach(async function () {


### PR DESCRIPTION
Incentives might result in minting perp so enforcing supply cap at the end of deposit, burn and rollover. 

Fixes #71 