### PR TITLE
Issuer update v1.1.0

### DIFF
--- a/spot-contracts/contracts/BondIssuer.sol
+++ b/spot-contracts/contracts/BondIssuer.sol
@@ -8,10 +8,7 @@ import { BondHelpers } from "./_utils/BondHelpers.sol";
 
 import { IBondFactory } from "./_interfaces/buttonwood/IBondFactory.sol";
 import { IBondController } from "./_interfaces/buttonwood/IBondController.sol";
-import { IBondIssuer } from "./_interfaces/IBondIssuer.sol";
-
-/// @notice Expected at least one mature bond.
-error NoMaturedBonds();
+import { IBondIssuer, NoMaturedBonds } from "./_interfaces/IBondIssuer.sol";
 
 /**
  *  @title BondIssuer
@@ -127,7 +124,7 @@ contract BondIssuer is IBondIssuer, OwnableUpgradeable {
 
     /// @inheritdoc IBondIssuer
     /// @dev Reverts if none of the active bonds are mature.
-    function matureAll() external {
+    function matureActive() external {
         bool bondsMature = false;
 
         // NOTE: We traverse the active index list in the reverse order as deletions involve

--- a/spot-contracts/contracts/BondIssuer.sol
+++ b/spot-contracts/contracts/BondIssuer.sol
@@ -187,4 +187,15 @@ contract BondIssuer is IBondIssuer, OwnableUpgradeable {
     function issuedBondAt(uint256 index) external view override returns (IBondController) {
         return IBondController(_issuedBonds.at(index));
     }
+
+    /// @inheritdoc IBondIssuer
+    function activeCount() external view override returns (uint256) {
+        return _activeBondIDXs.length;
+    }
+
+    /// @inheritdoc IBondIssuer
+    /// @dev This is NOT ordered by issuance time.
+    function activeBondAt(uint256 index) external view override returns (IBondController) {
+        return IBondController(_issuedBonds.at(_activeBondIDXs[index]));
+    }
 }

--- a/spot-contracts/contracts/BondIssuer.sol
+++ b/spot-contracts/contracts/BondIssuer.sol
@@ -188,14 +188,17 @@ contract BondIssuer is IBondIssuer, OwnableUpgradeable {
         return IBondController(_issuedBonds.at(index));
     }
 
-    /// @inheritdoc IBondIssuer
-    function activeCount() external view override returns (uint256) {
+    /// @notice Number of bonds issued by this issuer which have not yet reached their maturity date.
+    /// @return Number of active bonds.
+    function activeCount() external view returns (uint256) {
         return _activeBondIDXs.length;
     }
 
-    /// @inheritdoc IBondIssuer
+    /// @notice The bond address from the active list by index.
     /// @dev This is NOT ordered by issuance time.
-    function activeBondAt(uint256 index) external view override returns (IBondController) {
+    /// @param index The index of the bond in the active list.
+    /// @return Address of the active bond.
+    function activeBondAt(uint256 index) external view returns (IBondController) {
         return IBondController(_issuedBonds.at(_activeBondIDXs[index]));
     }
 }

--- a/spot-contracts/contracts/_interfaces/IBondIssuer.sol
+++ b/spot-contracts/contracts/_interfaces/IBondIssuer.sol
@@ -8,9 +8,16 @@ interface IBondIssuer {
     /// @param bond The newly issued bond.
     event BondIssued(IBondController bond);
 
+    /// @notice Event emitted when a bond has matured.
+    /// @param bond The mature bond.
+    event BondMature(IBondController bond);
+
     /// @notice The address of the underlying collateral token to be used for issued bonds.
     /// @return Address of the collateral token.
     function collateral() external view returns (address);
+
+    /// @notice Invokes `mature` on issued bonds.
+    function matureAll() external;
 
     /// @notice Issues a new bond if sufficient time has elapsed since the last issue.
     function issue() external;

--- a/spot-contracts/contracts/_interfaces/IBondIssuer.sol
+++ b/spot-contracts/contracts/_interfaces/IBondIssuer.sol
@@ -41,4 +41,12 @@ interface IBondIssuer {
     /// @notice The bond address from the issued list by index.
     /// @return Address of the bond.
     function issuedBondAt(uint256 index) external view returns (IBondController);
+
+    /// @notice The total number of bonds issued by this issuer which are currently active.
+    /// @return Number of active bonds.
+    function activeCount() external view returns (uint256);
+
+    /// @notice The bond address from the active list by index.
+    /// @return Address of the active bond.
+    function activeBondAt(uint256 index) external view returns (IBondController);
 }

--- a/spot-contracts/contracts/_interfaces/IBondIssuer.sol
+++ b/spot-contracts/contracts/_interfaces/IBondIssuer.sol
@@ -9,7 +9,7 @@ interface IBondIssuer {
     event BondIssued(IBondController bond);
 
     /// @notice Event emitted when a bond has matured.
-    /// @param bond The mature bond.
+    /// @param bond The matured bond.
     event BondMature(IBondController bond);
 
     /// @notice The address of the underlying collateral token to be used for issued bonds.

--- a/spot-contracts/contracts/_interfaces/IBondIssuer.sol
+++ b/spot-contracts/contracts/_interfaces/IBondIssuer.sol
@@ -39,6 +39,7 @@ interface IBondIssuer {
     function issuedCount() external view returns (uint256);
 
     /// @notice The bond address from the issued list by index.
+    /// @param index The index of the bond in the issued list.
     /// @return Address of the bond.
     function issuedBondAt(uint256 index) external view returns (IBondController);
 
@@ -47,6 +48,7 @@ interface IBondIssuer {
     function activeCount() external view returns (uint256);
 
     /// @notice The bond address from the active list by index.
+    /// @param index The index of the bond in the active list.
     /// @return Address of the active bond.
     function activeBondAt(uint256 index) external view returns (IBondController);
 }

--- a/spot-contracts/contracts/_interfaces/IBondIssuer.sol
+++ b/spot-contracts/contracts/_interfaces/IBondIssuer.sol
@@ -42,7 +42,7 @@ interface IBondIssuer {
     /// @return Address of the bond.
     function issuedBondAt(uint256 index) external view returns (IBondController);
 
-    /// @notice The total number of bonds issued by this issuer which are currently active.
+    /// @notice Number of bonds issued by this issuer which have not yet reached their maturity date.
     /// @return Number of active bonds.
     function activeCount() external view returns (uint256);
 

--- a/spot-contracts/contracts/_interfaces/IBondIssuer.sol
+++ b/spot-contracts/contracts/_interfaces/IBondIssuer.sol
@@ -3,6 +3,9 @@ pragma solidity ^0.8.0;
 
 import { IBondController } from "./buttonwood/IBondController.sol";
 
+/// @notice Expected at least one matured bond.
+error NoMaturedBonds();
+
 interface IBondIssuer {
     /// @notice Event emitted when a new bond is issued by the issuer.
     /// @param bond The newly issued bond.
@@ -16,8 +19,8 @@ interface IBondIssuer {
     /// @return Address of the collateral token.
     function collateral() external view returns (address);
 
-    /// @notice Invokes `mature` on issued bonds.
-    function matureAll() external;
+    /// @notice Invokes `mature` on issued active bonds.
+    function matureActive() external;
 
     /// @notice Issues a new bond if sufficient time has elapsed since the last issue.
     function issue() external;

--- a/spot-contracts/contracts/_interfaces/IBondIssuer.sol
+++ b/spot-contracts/contracts/_interfaces/IBondIssuer.sol
@@ -42,13 +42,4 @@ interface IBondIssuer {
     /// @param index The index of the bond in the issued list.
     /// @return Address of the bond.
     function issuedBondAt(uint256 index) external view returns (IBondController);
-
-    /// @notice Number of bonds issued by this issuer which have not yet reached their maturity date.
-    /// @return Number of active bonds.
-    function activeCount() external view returns (uint256);
-
-    /// @notice The bond address from the active list by index.
-    /// @param index The index of the bond in the active list.
-    /// @return Address of the active bond.
-    function activeBondAt(uint256 index) external view returns (IBondController);
 }

--- a/spot-contracts/test/BondIssuer.ts
+++ b/spot-contracts/test/BondIssuer.ts
@@ -41,6 +41,8 @@ describe("BondIssuer", function () {
       expect(await issuer.lastIssueWindowTimestamp()).to.eq(0);
       expect(await issuer.issuedCount()).to.eq(0);
       await expect(issuer.issuedBondAt(0)).to.be.reverted;
+      expect(await issuer.activeCount()).to.eq(0);
+      await expect(issuer.activeBondAt(0)).to.be.reverted;
     });
   });
 
@@ -117,6 +119,10 @@ describe("BondIssuer", function () {
         expect(await issuer.issuedBondAt(0)).to.eq(bond);
         await expect(issuer.issuedBondAt(1)).to.be.reverted;
 
+        expect(await issuer.activeCount()).to.eq(1);
+        expect(await issuer.activeBondAt(0)).to.eq(bond);
+        await expect(issuer.activeBondAt(1)).to.be.reverted;
+
         await TimeHelpers.setNextBlockTimestamp(mockTime(4495));
         await expect(issuer.issue()).not.to.emit(issuer, "BondIssued");
         expect(await issuer.lastIssueWindowTimestamp()).to.eq(mockTime(900));
@@ -127,6 +133,9 @@ describe("BondIssuer", function () {
 
         expect(await issuer.issuedCount()).to.eq(2);
         await expect(issuer.issuedBondAt(1)).to.not.be.reverted;
+
+        expect(await issuer.activeCount()).to.eq(2);
+        await expect(issuer.activeBondAt(1)).to.not.be.reverted;
 
         await TimeHelpers.setNextBlockTimestamp(mockTime(4505));
         await expect(issuer.issue()).not.to.emit(issuer, "BondIssued");
@@ -224,6 +233,8 @@ describe("BondIssuer", function () {
         lastBond = await bondAt(await issuer.callStatic.getLatestBond());
         expect(await issuer.issuedCount()).to.eq(1);
         expect(await issuer.issuedBondAt(0)).to.eq(lastBond.address);
+        expect(await issuer.activeCount()).to.eq(1);
+        expect(await issuer.activeBondAt(0)).to.eq(lastBond.address);
 
         await TimeHelpers.setNextBlockTimestamp(mockTime(87301));
         tx = issuer.matureActive();
@@ -236,6 +247,8 @@ describe("BondIssuer", function () {
       it("should keep track of active and mature bonds", async function () {
         expect(await issuer.issuedCount()).to.eq(1);
         expect(await issuer.issuedBondAt(0)).to.eq(lastBond.address);
+        expect(await issuer.activeCount()).to.eq(0);
+        await expect(issuer.activeBondAt(0)).to.be.reverted;
       });
     });
 
@@ -260,6 +273,8 @@ describe("BondIssuer", function () {
       it("should keep track of active and mature bonds", async function () {
         expect(await issuer.issuedCount()).to.eq(1);
         expect(await issuer.issuedBondAt(0)).to.eq(lastBond.address);
+        expect(await issuer.activeCount()).to.eq(0);
+        await expect(issuer.activeBondAt(0)).to.be.reverted;
       });
     });
 
@@ -283,6 +298,11 @@ describe("BondIssuer", function () {
         expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
         expect(await issuer.issuedBondAt(2)).to.eq(b3.address);
 
+        expect(await issuer.activeCount()).to.eq(3);
+        expect(await issuer.activeBondAt(0)).to.eq(b1.address);
+        expect(await issuer.activeBondAt(1)).to.eq(b2.address);
+        expect(await issuer.activeBondAt(2)).to.eq(b3.address);
+
         tx = issuer.matureActive();
         await tx;
       });
@@ -295,6 +315,10 @@ describe("BondIssuer", function () {
         expect(await issuer.issuedBondAt(0)).to.eq(b1.address);
         expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
         expect(await issuer.issuedBondAt(2)).to.eq(b3.address);
+        expect(await issuer.activeCount()).to.eq(2);
+        expect(await issuer.activeBondAt(0)).to.eq(b3.address);
+        expect(await issuer.activeBondAt(1)).to.eq(b2.address);
+        await expect(issuer.activeBondAt(2)).to.be.reverted;
       });
     });
 
@@ -320,6 +344,11 @@ describe("BondIssuer", function () {
         expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
         expect(await issuer.issuedBondAt(2)).to.eq(b3.address);
 
+        expect(await issuer.activeCount()).to.eq(3);
+        expect(await issuer.activeBondAt(0)).to.eq(b1.address);
+        expect(await issuer.activeBondAt(1)).to.eq(b2.address);
+        expect(await issuer.activeBondAt(2)).to.eq(b3.address);
+
         tx = issuer.matureActive();
         await tx;
       });
@@ -334,6 +363,9 @@ describe("BondIssuer", function () {
         expect(await issuer.issuedBondAt(0)).to.eq(b1.address);
         expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
         expect(await issuer.issuedBondAt(2)).to.eq(b3.address);
+        expect(await issuer.activeCount()).to.eq(1);
+        expect(await issuer.activeBondAt(0)).to.eq(b3.address);
+        await expect(issuer.activeBondAt(1)).to.be.reverted;
       });
     });
 
@@ -359,6 +391,11 @@ describe("BondIssuer", function () {
         expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
         expect(await issuer.issuedBondAt(2)).to.eq(b3.address);
 
+        expect(await issuer.activeCount()).to.eq(3);
+        expect(await issuer.activeBondAt(0)).to.eq(b1.address);
+        expect(await issuer.activeBondAt(1)).to.eq(b2.address);
+        expect(await issuer.activeBondAt(2)).to.eq(b3.address);
+
         tx = issuer.matureActive();
         await tx;
       });
@@ -375,6 +412,8 @@ describe("BondIssuer", function () {
         expect(await issuer.issuedBondAt(0)).to.eq(b1.address);
         expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
         expect(await issuer.issuedBondAt(2)).to.eq(b3.address);
+        expect(await issuer.activeCount()).to.eq(0);
+        await expect(issuer.activeBondAt(0)).to.be.reverted;
       });
     });
   });

--- a/spot-contracts/test/BondIssuer.ts
+++ b/spot-contracts/test/BondIssuer.ts
@@ -1,8 +1,8 @@
 import { expect } from "chai";
 import { ethers, network } from "hardhat";
-import { Contract, Signer } from "ethers";
+import { Contract, Transaction, Signer } from "ethers";
 
-import { TimeHelpers, setupBondFactory } from "./helpers";
+import { TimeHelpers, setupBondFactory, bondAt } from "./helpers";
 
 const START_TIME = 2499998400;
 const mockTime = (x: number) => START_TIME + x;
@@ -199,6 +199,192 @@ describe("BondIssuer", function () {
         const bond = bondIssuedEvent.args.bond;
         expect(await issuer.callStatic.getLatestBond()).to.eq(bond);
         await expect(issuer.getLatestBond()).to.not.emit(issuer, "BondIssued");
+      });
+    });
+  });
+
+  describe("#matureAll", function () {
+    describe("active set has one bond and it is NOT up for maturity", function () {
+      beforeEach(async function () {
+        await TimeHelpers.setNextBlockTimestamp(mockTime(900));
+        await issuer.issue();
+        await TimeHelpers.setNextBlockTimestamp(mockTime(87295));
+      });
+
+      it("should revert", async function () {
+        await expect(issuer.matureAll()).to.be.revertedWith("NoMaturedBonds");
+      });
+    });
+
+    describe("active set has one bond and it is up for maturity", function () {
+      let lastBond: Contract, tx: Transaction;
+      beforeEach(async function () {
+        await TimeHelpers.setNextBlockTimestamp(mockTime(900));
+        await issuer.issue();
+        lastBond = await bondAt(await issuer.callStatic.getLatestBond());
+        expect(await issuer.activeCount()).to.eq(1);
+        expect(await issuer.issuedCount()).to.eq(1);
+        expect(await issuer.issuedBondAt(0)).to.eq(lastBond.address);
+
+        await TimeHelpers.setNextBlockTimestamp(mockTime(87301));
+        tx = issuer.matureAll();
+        await tx;
+      });
+      it("should emit mature", async function () {
+        await expect(tx).to.emit(issuer, "BondMature").withArgs(lastBond.address);
+        await expect(tx).to.emit(lastBond, "Mature");
+      });
+      it("should keep track of active and mature bonds", async function () {
+        expect(await issuer.activeCount()).to.eq(0);
+        expect(await issuer.issuedCount()).to.eq(1);
+        expect(await issuer.issuedBondAt(0)).to.eq(lastBond.address);
+      });
+    });
+
+    describe("active set has one bond and it is up for maturity by `mature` was already invoked", function () {
+      let lastBond: Contract, tx: Transaction;
+      beforeEach(async function () {
+        await TimeHelpers.setNextBlockTimestamp(mockTime(900));
+        await issuer.issue();
+        lastBond = await bondAt(await issuer.callStatic.getLatestBond());
+        expect(await issuer.activeCount()).to.eq(1);
+        expect(await issuer.issuedCount()).to.eq(1);
+        expect(await issuer.issuedBondAt(0)).to.eq(lastBond.address);
+
+        await TimeHelpers.setNextBlockTimestamp(mockTime(87301));
+        await lastBond.mature();
+        tx = issuer.matureAll();
+        await tx;
+      });
+      it("should NOT emit mature", async function () {
+        await expect(tx).to.emit(issuer, "BondMature");
+        await expect(tx).not.to.emit(lastBond, "Mature");
+      });
+      it("should keep track of active and mature bonds", async function () {
+        expect(await issuer.activeCount()).to.eq(0);
+        expect(await issuer.issuedCount()).to.eq(1);
+        expect(await issuer.issuedBondAt(0)).to.eq(lastBond.address);
+      });
+    });
+
+    describe("active set has many bonds and one is up for maturity", function () {
+      let b1: Contract, b2: Contract, b3: Contract, tx: Transaction;
+      beforeEach(async function () {
+        await TimeHelpers.setNextBlockTimestamp(mockTime(900));
+        await issuer.issue();
+        b1 = await bondAt(await issuer.callStatic.getLatestBond());
+
+        await TimeHelpers.setNextBlockTimestamp(mockTime(83700));
+        await issuer.issue();
+        b2 = await bondAt(await issuer.callStatic.getLatestBond());
+
+        await TimeHelpers.setNextBlockTimestamp(mockTime(87300));
+        await issuer.issue();
+        b3 = await bondAt(await issuer.callStatic.getLatestBond());
+
+        expect(await issuer.activeCount()).to.eq(3);
+        expect(await issuer.issuedCount()).to.eq(3);
+        expect(await issuer.issuedBondAt(0)).to.eq(b1.address);
+        expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
+        expect(await issuer.issuedBondAt(2)).to.eq(b3.address);
+
+        tx = issuer.matureAll();
+        await tx;
+      });
+      it("should emit mature on the oldest bond", async function () {
+        await expect(tx).to.emit(b1, "Mature");
+        await expect(tx).to.emit(issuer, "BondMature").withArgs(b1.address);
+      });
+      it("should keep track of active and mature bonds", async function () {
+        expect(await issuer.activeCount()).to.eq(2);
+        expect(await issuer.issuedCount()).to.eq(3);
+        expect(await issuer.issuedBondAt(0)).to.eq(b3.address);
+        expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
+        expect(await issuer.issuedBondAt(2)).to.eq(b1.address);
+      });
+    });
+
+    describe("active set has many bonds and many are up for maturity", function () {
+      let b1: Contract, b2: Contract, b3: Contract, tx: Transaction;
+      beforeEach(async function () {
+        await TimeHelpers.setNextBlockTimestamp(mockTime(900));
+        await issuer.issue();
+        b1 = await bondAt(await issuer.callStatic.getLatestBond());
+
+        await TimeHelpers.setNextBlockTimestamp(mockTime(83700));
+        await issuer.issue();
+        b2 = await bondAt(await issuer.callStatic.getLatestBond());
+
+        await TimeHelpers.setNextBlockTimestamp(mockTime(87300));
+        await issuer.issue();
+        b3 = await bondAt(await issuer.callStatic.getLatestBond());
+
+        await TimeHelpers.setNextBlockTimestamp(mockTime(170100));
+
+        expect(await issuer.activeCount()).to.eq(3);
+        expect(await issuer.issuedCount()).to.eq(3);
+        expect(await issuer.issuedBondAt(0)).to.eq(b1.address);
+        expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
+        expect(await issuer.issuedBondAt(2)).to.eq(b3.address);
+
+        tx = issuer.matureAll();
+        await tx;
+      });
+      it("should emit mature", async function () {
+        await expect(tx).to.emit(b1, "Mature");
+        await expect(tx).to.emit(issuer, "BondMature").withArgs(b1.address);
+        await expect(tx).to.emit(b2, "Mature");
+        await expect(tx).to.emit(issuer, "BondMature").withArgs(b2.address);
+      });
+      it("should keep track of active and mature bonds", async function () {
+        expect(await issuer.activeCount()).to.eq(1);
+        expect(await issuer.issuedCount()).to.eq(3);
+        expect(await issuer.issuedBondAt(0)).to.eq(b3.address);
+        expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
+        expect(await issuer.issuedBondAt(2)).to.eq(b1.address);
+      });
+    });
+
+    describe("active set has many bonds and all are up for maturity", function () {
+      let b1: Contract, b2: Contract, b3: Contract, tx: Transaction;
+      beforeEach(async function () {
+        await TimeHelpers.setNextBlockTimestamp(mockTime(900));
+        await issuer.issue();
+        b1 = await bondAt(await issuer.callStatic.getLatestBond());
+
+        await TimeHelpers.setNextBlockTimestamp(mockTime(83700));
+        await issuer.issue();
+        b2 = await bondAt(await issuer.callStatic.getLatestBond());
+
+        await TimeHelpers.setNextBlockTimestamp(mockTime(87300));
+        await issuer.issue();
+        b3 = await bondAt(await issuer.callStatic.getLatestBond());
+
+        await TimeHelpers.setNextBlockTimestamp(mockTime(260100));
+
+        expect(await issuer.activeCount()).to.eq(3);
+        expect(await issuer.issuedCount()).to.eq(3);
+        expect(await issuer.issuedBondAt(0)).to.eq(b1.address);
+        expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
+        expect(await issuer.issuedBondAt(2)).to.eq(b3.address);
+
+        tx = issuer.matureAll();
+        await tx;
+      });
+      it("should emit mature", async function () {
+        await expect(tx).to.emit(b1, "Mature");
+        await expect(tx).to.emit(issuer, "BondMature").withArgs(b1.address);
+        await expect(tx).to.emit(b2, "Mature");
+        await expect(tx).to.emit(issuer, "BondMature").withArgs(b2.address);
+        await expect(tx).to.emit(b3, "Mature");
+        await expect(tx).to.emit(issuer, "BondMature").withArgs(b3.address);
+      });
+      it("should keep track of active and mature bonds", async function () {
+        expect(await issuer.activeCount()).to.eq(0);
+        expect(await issuer.issuedCount()).to.eq(3);
+        expect(await issuer.issuedBondAt(0)).to.eq(b3.address);
+        expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
+        expect(await issuer.issuedBondAt(2)).to.eq(b1.address);
       });
     });
   });

--- a/spot-contracts/test/BondIssuer.ts
+++ b/spot-contracts/test/BondIssuer.ts
@@ -203,7 +203,7 @@ describe("BondIssuer", function () {
     });
   });
 
-  describe.only("#matureAll", function () {
+  describe("#matureActive", function () {
     describe("active set has one bond and it is NOT up for maturity", function () {
       beforeEach(async function () {
         await TimeHelpers.setNextBlockTimestamp(mockTime(900));
@@ -212,7 +212,7 @@ describe("BondIssuer", function () {
       });
 
       it("should revert", async function () {
-        await expect(issuer.matureAll()).to.be.revertedWith("NoMaturedBonds");
+        await expect(issuer.matureActive()).to.be.revertedWith("NoMaturedBonds");
       });
     });
 
@@ -226,7 +226,7 @@ describe("BondIssuer", function () {
         expect(await issuer.issuedBondAt(0)).to.eq(lastBond.address);
 
         await TimeHelpers.setNextBlockTimestamp(mockTime(87301));
-        tx = issuer.matureAll();
+        tx = issuer.matureActive();
         await tx;
       });
       it("should emit mature", async function () {
@@ -250,7 +250,7 @@ describe("BondIssuer", function () {
 
         await TimeHelpers.setNextBlockTimestamp(mockTime(87301));
         await lastBond.mature();
-        tx = issuer.matureAll();
+        tx = issuer.matureActive();
         await tx;
       });
       it("should NOT emit mature", async function () {
@@ -283,7 +283,7 @@ describe("BondIssuer", function () {
         expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
         expect(await issuer.issuedBondAt(2)).to.eq(b3.address);
 
-        tx = issuer.matureAll();
+        tx = issuer.matureActive();
         await tx;
       });
       it("should emit mature on the oldest bond", async function () {
@@ -320,7 +320,7 @@ describe("BondIssuer", function () {
         expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
         expect(await issuer.issuedBondAt(2)).to.eq(b3.address);
 
-        tx = issuer.matureAll();
+        tx = issuer.matureActive();
         await tx;
       });
       it("should emit mature", async function () {
@@ -359,7 +359,7 @@ describe("BondIssuer", function () {
         expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
         expect(await issuer.issuedBondAt(2)).to.eq(b3.address);
 
-        tx = issuer.matureAll();
+        tx = issuer.matureActive();
         await tx;
       });
       it("should emit mature", async function () {

--- a/spot-contracts/test/BondIssuer.ts
+++ b/spot-contracts/test/BondIssuer.ts
@@ -203,7 +203,7 @@ describe("BondIssuer", function () {
     });
   });
 
-  describe("#matureAll", function () {
+  describe.only("#matureAll", function () {
     describe("active set has one bond and it is NOT up for maturity", function () {
       beforeEach(async function () {
         await TimeHelpers.setNextBlockTimestamp(mockTime(900));
@@ -222,7 +222,6 @@ describe("BondIssuer", function () {
         await TimeHelpers.setNextBlockTimestamp(mockTime(900));
         await issuer.issue();
         lastBond = await bondAt(await issuer.callStatic.getLatestBond());
-        expect(await issuer.activeCount()).to.eq(1);
         expect(await issuer.issuedCount()).to.eq(1);
         expect(await issuer.issuedBondAt(0)).to.eq(lastBond.address);
 
@@ -235,7 +234,6 @@ describe("BondIssuer", function () {
         await expect(tx).to.emit(lastBond, "Mature");
       });
       it("should keep track of active and mature bonds", async function () {
-        expect(await issuer.activeCount()).to.eq(0);
         expect(await issuer.issuedCount()).to.eq(1);
         expect(await issuer.issuedBondAt(0)).to.eq(lastBond.address);
       });
@@ -247,7 +245,6 @@ describe("BondIssuer", function () {
         await TimeHelpers.setNextBlockTimestamp(mockTime(900));
         await issuer.issue();
         lastBond = await bondAt(await issuer.callStatic.getLatestBond());
-        expect(await issuer.activeCount()).to.eq(1);
         expect(await issuer.issuedCount()).to.eq(1);
         expect(await issuer.issuedBondAt(0)).to.eq(lastBond.address);
 
@@ -261,7 +258,6 @@ describe("BondIssuer", function () {
         await expect(tx).not.to.emit(lastBond, "Mature");
       });
       it("should keep track of active and mature bonds", async function () {
-        expect(await issuer.activeCount()).to.eq(0);
         expect(await issuer.issuedCount()).to.eq(1);
         expect(await issuer.issuedBondAt(0)).to.eq(lastBond.address);
       });
@@ -282,7 +278,6 @@ describe("BondIssuer", function () {
         await issuer.issue();
         b3 = await bondAt(await issuer.callStatic.getLatestBond());
 
-        expect(await issuer.activeCount()).to.eq(3);
         expect(await issuer.issuedCount()).to.eq(3);
         expect(await issuer.issuedBondAt(0)).to.eq(b1.address);
         expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
@@ -296,11 +291,10 @@ describe("BondIssuer", function () {
         await expect(tx).to.emit(issuer, "BondMature").withArgs(b1.address);
       });
       it("should keep track of active and mature bonds", async function () {
-        expect(await issuer.activeCount()).to.eq(2);
         expect(await issuer.issuedCount()).to.eq(3);
-        expect(await issuer.issuedBondAt(0)).to.eq(b3.address);
+        expect(await issuer.issuedBondAt(0)).to.eq(b1.address);
         expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
-        expect(await issuer.issuedBondAt(2)).to.eq(b1.address);
+        expect(await issuer.issuedBondAt(2)).to.eq(b3.address);
       });
     });
 
@@ -321,7 +315,6 @@ describe("BondIssuer", function () {
 
         await TimeHelpers.setNextBlockTimestamp(mockTime(170100));
 
-        expect(await issuer.activeCount()).to.eq(3);
         expect(await issuer.issuedCount()).to.eq(3);
         expect(await issuer.issuedBondAt(0)).to.eq(b1.address);
         expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
@@ -337,11 +330,10 @@ describe("BondIssuer", function () {
         await expect(tx).to.emit(issuer, "BondMature").withArgs(b2.address);
       });
       it("should keep track of active and mature bonds", async function () {
-        expect(await issuer.activeCount()).to.eq(1);
         expect(await issuer.issuedCount()).to.eq(3);
-        expect(await issuer.issuedBondAt(0)).to.eq(b3.address);
+        expect(await issuer.issuedBondAt(0)).to.eq(b1.address);
         expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
-        expect(await issuer.issuedBondAt(2)).to.eq(b1.address);
+        expect(await issuer.issuedBondAt(2)).to.eq(b3.address);
       });
     });
 
@@ -362,7 +354,6 @@ describe("BondIssuer", function () {
 
         await TimeHelpers.setNextBlockTimestamp(mockTime(260100));
 
-        expect(await issuer.activeCount()).to.eq(3);
         expect(await issuer.issuedCount()).to.eq(3);
         expect(await issuer.issuedBondAt(0)).to.eq(b1.address);
         expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
@@ -380,11 +371,10 @@ describe("BondIssuer", function () {
         await expect(tx).to.emit(issuer, "BondMature").withArgs(b3.address);
       });
       it("should keep track of active and mature bonds", async function () {
-        expect(await issuer.activeCount()).to.eq(0);
         expect(await issuer.issuedCount()).to.eq(3);
-        expect(await issuer.issuedBondAt(0)).to.eq(b3.address);
+        expect(await issuer.issuedBondAt(0)).to.eq(b1.address);
         expect(await issuer.issuedBondAt(1)).to.eq(b2.address);
-        expect(await issuer.issuedBondAt(2)).to.eq(b1.address);
+        expect(await issuer.issuedBondAt(2)).to.eq(b3.address);
       });
     });
   });


### PR DESCRIPTION
- updated issuer book keeping to keep track of active bond indices
- Added helper to execute `mature` on active bonds when they are up for maturity 