### PR TITLE
Min deployment amount enforcement

### DIFF
--- a/spot-contracts/contracts/_interfaces/IVault.sol
+++ b/spot-contracts/contracts/_interfaces/IVault.sol
@@ -11,8 +11,8 @@ error UnexpectedAsset(IERC20Upgradeable token);
 /// @param token Address of the token transferred.
 error UnauthorizedTransferOut(IERC20Upgradeable token);
 
-/// @notice Expected vault assets to be deployed.
-error NoDeployment();
+/// @notice Expected a minimum amount of vault assets to be deployed.
+error InsufficientDeployment();
 
 /// @notice Expected the number of vault assets deployed to be under the limit.
 error DeployedCountOverLimit();

--- a/spot-contracts/contracts/_interfaces/IVault.sol
+++ b/spot-contracts/contracts/_interfaces/IVault.sol
@@ -76,6 +76,10 @@ interface IVault {
     /// @return The total value of assets currently held by the vault, denominated in a standard unit of account.
     function getTVL() external returns (uint256);
 
+    /// @param token The address of the asset ERC-20 token held by the vault.
+    /// @return The vault's asset token value, denominated in a standard unit of account.
+    function getVaultAssetValue(IERC20Upgradeable token) external returns (uint256);
+
     /// @notice The ERC20 token that can be deposited into this vault.
     function underlying() external view returns (IERC20Upgradeable);
 

--- a/spot-contracts/contracts/vaults/RolloverVault.sol
+++ b/spot-contracts/contracts/vaults/RolloverVault.sol
@@ -78,7 +78,7 @@ contract RolloverVault is
     //-------------------------------------------------------------------------
     // Storage
 
-    /// @notice The enforced minimum amount of assets to that have to be deployed in each iteration.
+    /// @notice Minimum amount of assets that must be deployed for a deploy operation to succeed, denominated in perps.
     /// @dev The deployment transaction reverts, if the vaults does not have sufficient usable balance
     ///      to cover the the minimum deployment amount.
     uint256 public minDeploymentAmt;
@@ -145,8 +145,8 @@ contract RolloverVault is
     }
 
     /// @notice Updates the minimum deployment amount.
-    /// @param minDeploymentAmt_ The new minimum deployment amount.
-    function updateMinDeploymentAmt(uint256 minDeploymentAmt_) public onlyOwner {
+    /// @param minDeploymentAmt_ The new minimum deployment amount, denominated in perps.
+    function updateMinDeploymentAmt(uint256 minDeploymentAmt_) external onlyOwner {
         minDeploymentAmt = minDeploymentAmt_;
     }
 

--- a/spot-contracts/contracts/vaults/RolloverVault.sol
+++ b/spot-contracts/contracts/vaults/RolloverVault.sol
@@ -181,6 +181,7 @@ contract RolloverVault is
     function deploy() public override nonReentrant whenNotPaused {
         (uint256 deployedAmt, TrancheData memory td) = _tranche(perp.getDepositBond());
         uint256 perpsRolledOver = _rollover(perp, td);
+        // NOTE: The following enforces that we only tranche the underlying if it can immediately be used for rotations.
         if (deployedAmt <= minDeploymentAmt || perpsRolledOver <= 0) {
             revert InsufficientDeployment();
         }

--- a/spot-contracts/contracts/vaults/RolloverVault.sol
+++ b/spot-contracts/contracts/vaults/RolloverVault.sol
@@ -80,7 +80,7 @@ contract RolloverVault is
 
     /// @notice Minimum amount of underlying assets that must be deployed, for a deploy operation to succeed.
     /// @dev The deployment transaction reverts, if the vaults does not have sufficient underlying tokens
-    ///      to cover the the minimum deployment amount.
+    ///      to cover the minimum deployment amount.
     uint256 public minDeploymentAmt;
 
     //--------------------------------------------------------------------------

--- a/spot-contracts/contracts/vaults/RolloverVault.sol
+++ b/spot-contracts/contracts/vaults/RolloverVault.sol
@@ -320,7 +320,7 @@ contract RolloverVault is
 
         // Skip if balance is zero
         if (balance <= 0) {
-            return (balance, td);
+            return (0, td);
         }
 
         // balance is tranched

--- a/spot-contracts/contracts/vaults/RolloverVault.sol
+++ b/spot-contracts/contracts/vaults/RolloverVault.sol
@@ -269,6 +269,31 @@ contract RolloverVault is
         return totalAssets;
     }
 
+    /// @inheritdoc IVault
+    /// @dev The asset value is denominated in the underlying asset.
+    function getVaultAssetValue(IERC20Upgradeable token) external override returns (uint256) {
+        uint256 balance = token.balanceOf(address(this));
+        if (balance <= 0) {
+            return 0;
+        }
+
+        // Underlying asset
+        if (token == underlying) {
+            return balance;
+        }
+        // Deployed asset
+        else if (_deployed.contains(address(token))) {
+            (uint256 collateralBalance, uint256 debt) = ITranche(address(token)).getTrancheCollateralization();
+            return balance.mulDiv(collateralBalance, debt);
+        }
+        // Earned asset
+        else if (address(token) == address(perp)) {
+            return balance.mulDiv(IPerpetualTranche(address(perp)).getAvgPrice(), PERP_UNIT_PRICE);
+        }
+
+        return 0;
+    }
+
     //--------------------------------------------------------------------------
     // External & Public read methods
 

--- a/spot-contracts/contracts/vaults/RolloverVault.sol
+++ b/spot-contracts/contracts/vaults/RolloverVault.sol
@@ -78,8 +78,8 @@ contract RolloverVault is
     //-------------------------------------------------------------------------
     // Storage
 
-    /// @notice Minimum amount of assets that must be deployed for a deploy operation to succeed, denominated in perps.
-    /// @dev The deployment transaction reverts, if the vaults does not have sufficient usable balance
+    /// @notice Minimum amount of underlying assets that must be deployed, for a deploy operation to succeed.
+    /// @dev The deployment transaction reverts, if the vaults does not have sufficient underlying tokens
     ///      to cover the the minimum deployment amount.
     uint256 public minDeploymentAmt;
 
@@ -145,7 +145,7 @@ contract RolloverVault is
     }
 
     /// @notice Updates the minimum deployment amount.
-    /// @param minDeploymentAmt_ The new minimum deployment amount, denominated in perps.
+    /// @param minDeploymentAmt_ The new minimum deployment amount, denominated in underlying tokens.
     function updateMinDeploymentAmt(uint256 minDeploymentAmt_) external onlyOwner {
         minDeploymentAmt = minDeploymentAmt_;
     }
@@ -179,9 +179,9 @@ contract RolloverVault is
     /// @dev Its safer to call `recover` before `deploy` so the full available balance can be deployed.
     ///      Reverts if no funds are rolled over or if the minimum deployment threshold is not reached.
     function deploy() public override nonReentrant whenNotPaused {
-        (uint256 underlyingDeployed, TrancheData memory td) = _tranche(perp.getDepositBond());
+        (uint256 deployedAmt, TrancheData memory td) = _tranche(perp.getDepositBond());
         uint256 perpsRolledOver = _rollover(perp, td);
-        if (underlyingDeployed <= minDeploymentAmt || perpsRolledOver <= 0) {
+        if (deployedAmt <= minDeploymentAmt || perpsRolledOver <= 0) {
             revert InsufficientDeployment();
         }
     }

--- a/spot-contracts/test/vaults/RolloverVault.ts
+++ b/spot-contracts/test/vaults/RolloverVault.ts
@@ -275,4 +275,29 @@ describe("RolloverVault", function () {
       });
     });
   });
+
+  describe("#updateMinDeploymentAmt", function () {
+    let tx: Transaction;
+    beforeEach(async function () {
+      await vault.connect(deployer).transferOwnership(await otherUser.getAddress());
+    });
+
+    describe("when triggered by non-owner", function () {
+      it("should revert", async function () {
+        await expect(vault.connect(deployer).updateMinDeploymentAmt(0)).to.be.revertedWith(
+          "Ownable: caller is not the owner",
+        );
+      });
+    });
+
+    describe("when triggered by owner", function () {
+      beforeEach(async function () {
+        tx = await vault.connect(otherUser).updateMinDeploymentAmt(toFixedPtAmt("1000"));
+        await tx;
+      });
+      it("should update the min deployment amount", async function () {
+        expect(await vault.minDeploymentAmt()).to.eq(toFixedPtAmt("1000"));
+      });
+    });
+  });
 });

--- a/spot-contracts/test/vaults/RolloverVault_deploy.ts
+++ b/spot-contracts/test/vaults/RolloverVault_deploy.ts
@@ -165,7 +165,27 @@ describe("RolloverVault", function () {
   describe("#deploy", function () {
     describe("when usable balance is zero", function () {
       it("should revert", async function () {
-        await expect(vault.deploy()).to.be.revertedWithCustomError(vault, "NoDeployment");
+        await expect(vault.deploy()).to.be.revertedWithCustomError(vault, "InsufficientDeployment");
+      });
+    });
+
+    describe("when usable balance is lower than the min deployment", function () {
+      beforeEach(async function () {
+        await collateralToken.transfer(vault.address, toFixedPtAmt("999"));
+        await vault.updateMinDeploymentAmt(toFixedPtAmt("1000"));
+      });
+      it("should revert", async function () {
+        await expect(vault.deploy()).to.be.revertedWithCustomError(vault, "InsufficientDeployment");
+      });
+    });
+
+    describe("when usable balance is higher than the min deployment", function () {
+      beforeEach(async function () {
+        await collateralToken.transfer(vault.address, toFixedPtAmt("1000"));
+        await vault.updateMinDeploymentAmt(toFixedPtAmt("100"));
+      });
+      it("should not revert", async function () {
+        await expect(vault.deploy()).not.to.be.reverted;
       });
     });
 
@@ -180,7 +200,7 @@ describe("RolloverVault", function () {
         await collateralToken.transfer(vault.address, toFixedPtAmt("10"));
       });
       it("should revert", async function () {
-        await expect(vault.deploy()).to.be.revertedWithCustomError(vault, "NoDeployment");
+        await expect(vault.deploy()).to.be.revertedWithCustomError(vault, "InsufficientDeployment");
       });
     });
 

--- a/spot-contracts/test/vaults/RolloverVault_deposit_redeem.ts
+++ b/spot-contracts/test/vaults/RolloverVault_deposit_redeem.ts
@@ -167,10 +167,12 @@ describe("RolloverVault", function () {
     expect(await vault.vaultAssetBalance(await vault.earnedAt(0))).to.eq(0);
   });
 
-  describe("#getTVL", function () {
+  describe("get asset value", function () {
     describe("when vault is empty", function () {
-      it("should return 0", async function () {
+      it("should return 0 vaule", async function () {
         expect(await vault.callStatic.getTVL()).to.eq(0);
+        expect(await vault.callStatic.getVaultAssetValue(collateralToken.address)).to.eq(0);
+        expect(await vault.callStatic.getVaultAssetValue(perp.address)).to.eq(0);
       });
     });
 
@@ -180,6 +182,10 @@ describe("RolloverVault", function () {
       });
       it("should return tvl", async function () {
         expect(await vault.callStatic.getTVL()).to.eq(toFixedPtAmt("100"));
+      });
+      it("should return asset value", async function () {
+        expect(await vault.callStatic.getVaultAssetValue(collateralToken.address)).to.eq(toFixedPtAmt("100"));
+        expect(await vault.callStatic.getVaultAssetValue(perp.address)).to.eq(0);
       });
     });
 
@@ -199,6 +205,11 @@ describe("RolloverVault", function () {
       it("should return tvl", async function () {
         expect(await vault.callStatic.getTVL()).to.eq(toFixedPtAmt("100"));
       });
+      it("should return asset value", async function () {
+        expect(await vault.callStatic.getVaultAssetValue(collateralToken.address)).to.eq(0);
+        expect(await vault.callStatic.getVaultAssetValue(reserveTranches[0].address)).to.eq(toFixedPtAmt("100"));
+        expect(await vault.callStatic.getVaultAssetValue(perp.address)).to.eq(0);
+      });
     });
 
     describe("when vault has only earned balance", function () {
@@ -207,6 +218,10 @@ describe("RolloverVault", function () {
       });
       it("should return tvl", async function () {
         expect(await vault.callStatic.getTVL()).to.eq(toFixedPtAmt("100"));
+      });
+      it("should return asset value", async function () {
+        expect(await vault.callStatic.getVaultAssetValue(collateralToken.address)).to.eq(0);
+        expect(await vault.callStatic.getVaultAssetValue(perp.address)).to.eq(toFixedPtAmt("100"));
       });
     });
 
@@ -219,6 +234,14 @@ describe("RolloverVault", function () {
       });
       it("should return tvl", async function () {
         expect(await vault.callStatic.getTVL()).to.eq(toFixedPtAmt("2200"));
+      });
+      it("should return asset value", async function () {
+        expect(await vault.callStatic.getVaultAssetValue(collateralToken.address)).to.eq(toFixedPtAmt("100"));
+        expect(await vault.callStatic.getVaultAssetValue(reserveTranches[0].address)).to.eq(toFixedPtAmt("200"));
+        expect(await vault.callStatic.getVaultAssetValue(reserveTranches[1].address)).to.eq(toFixedPtAmt("200"));
+        expect(await vault.callStatic.getVaultAssetValue(rolloverInTranches[1].address)).to.eq(toFixedPtAmt("600"));
+        expect(await vault.callStatic.getVaultAssetValue(rolloverInTranches[2].address)).to.eq(toFixedPtAmt("1000"));
+        expect(await vault.callStatic.getVaultAssetValue(perp.address)).to.eq(toFixedPtAmt("100"));
       });
     });
 
@@ -233,6 +256,14 @@ describe("RolloverVault", function () {
       it("should return tvl", async function () {
         expect(await vault.callStatic.getTVL()).to.eq(toFixedPtAmt("2410"));
       });
+      it("should return asset value", async function () {
+        expect(await vault.callStatic.getVaultAssetValue(collateralToken.address)).to.eq(toFixedPtAmt("110"));
+        expect(await vault.callStatic.getVaultAssetValue(reserveTranches[0].address)).to.eq(toFixedPtAmt("200"));
+        expect(await vault.callStatic.getVaultAssetValue(reserveTranches[1].address)).to.eq(toFixedPtAmt("200"));
+        expect(await vault.callStatic.getVaultAssetValue(rolloverInTranches[1].address)).to.eq(toFixedPtAmt("600"));
+        expect(await vault.callStatic.getVaultAssetValue(rolloverInTranches[2].address)).to.eq(toFixedPtAmt("1200"));
+        expect(await vault.callStatic.getVaultAssetValue(perp.address)).to.eq(toFixedPtAmt("100"));
+      });
     });
 
     describe("when vault has many balances and rebases down", function () {
@@ -245,6 +276,14 @@ describe("RolloverVault", function () {
       });
       it("should return tvl", async function () {
         expect(await vault.callStatic.getTVL()).to.eq(toFixedPtAmt("1990"));
+      });
+      it("should return asset value", async function () {
+        expect(await vault.callStatic.getVaultAssetValue(collateralToken.address)).to.eq(toFixedPtAmt("90"));
+        expect(await vault.callStatic.getVaultAssetValue(reserveTranches[0].address)).to.eq(toFixedPtAmt("200"));
+        expect(await vault.callStatic.getVaultAssetValue(reserveTranches[1].address)).to.eq(toFixedPtAmt("200"));
+        expect(await vault.callStatic.getVaultAssetValue(rolloverInTranches[1].address)).to.eq(toFixedPtAmt("600"));
+        expect(await vault.callStatic.getVaultAssetValue(rolloverInTranches[2].address)).to.eq(toFixedPtAmt("800"));
+        expect(await vault.callStatic.getVaultAssetValue(perp.address)).to.eq(toFixedPtAmt("100"));
       });
     });
 
@@ -286,6 +325,17 @@ describe("RolloverVault", function () {
       });
       it("should return tvl", async function () {
         expect(await vault.callStatic.getTVL()).to.eq(toFixedPtAmt("390"));
+      });
+
+      it("should return asset value", async function () {
+        expect(await vault.callStatic.getVaultAssetValue(collateralToken.address)).to.eq(toFixedPtAmt("10"));
+        expect(await vault.callStatic.getVaultAssetValue(reserveTranches[0].address)).to.eq(toFixedPtAmt("100"));
+        expect(await vault.callStatic.getVaultAssetValue(reserveTranches[1].address)).to.eq(toFixedPtAmt("0"));
+        expect(await vault.callStatic.getVaultAssetValue(reserveTranches[2].address)).to.eq(toFixedPtAmt("0"));
+        expect(await vault.callStatic.getVaultAssetValue(rolloverInTranches[0].address)).to.eq(toFixedPtAmt("250"));
+        expect(await vault.callStatic.getVaultAssetValue(rolloverInTranches[1].address)).to.eq(toFixedPtAmt("0"));
+        expect(await vault.callStatic.getVaultAssetValue(rolloverInTranches[2].address)).to.eq(toFixedPtAmt("0"));
+        expect(await vault.callStatic.getVaultAssetValue(perp.address)).to.eq(toFixedPtAmt("30"));
       });
     });
   });


### PR DESCRIPTION
* Enforcing a minimum amount to be deployed
* Guards against potential grief from dust tokens which could trigger `recoverAndRedeploy`
* Contract owner can control `minDeploymentAmt` param