### PR TITLE
Recovery optimization

### DIFF
--- a/spot-contracts/contracts/_utils/BondHelpers.sol
+++ b/spot-contracts/contracts/_utils/BondHelpers.sol
@@ -99,6 +99,15 @@ library BondHelpers {
         return td;
     }
 
+    /// @notice Given a bond, returns the tranche at the specified index.
+    /// @param b The address of the bond contract.
+    /// @param i Index of the tranche.
+    /// @return t The tranche address.
+    function trancheAt(IBondController b, uint8 i) internal view returns (ITranche t) {
+        (t, ) = b.tranches(i);
+        return t;
+    }
+
     /// @notice Helper function to estimate the amount of tranches minted when a given amount of collateral
     ///         is deposited into the bond.
     /// @dev This function is used off-chain services (using callStatic) to preview tranches minted after

--- a/spot-contracts/test/vaults/RolloverVault_recover.ts
+++ b/spot-contracts/test/vaults/RolloverVault_recover.ts
@@ -551,7 +551,6 @@ describe("RolloverVault", function () {
           const tx = vault["recover(address)"](currentTranchesIn[1].address);
           await expect(tx).to.emit(vault, "AssetSynced").withArgs(collateralToken.address, toFixedPtAmt("5"));
           await expect(tx).to.emit(vault, "AssetSynced").withArgs(currentTranchesIn[1].address, toFixedPtAmt("0"));
-          await expect(tx).to.emit(vault, "AssetSynced").withArgs(currentTranchesIn[2].address, toFixedPtAmt("5"));
         });
       });
 


### PR DESCRIPTION
**Gas numbers before**
```
·-------------------------------------------------------|---------------------------|-------------|-----------------------------·
|                 Solc version: 0.8.19                  ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 30000000 gas  │
························································|···························|·············|······························
|  Methods                                              ·              122 gwei/gas               ·       1847.70 usd/eth       │
·····················|··································|·············|·············|·············|···············|··············
|  Contract          ·  Method                          ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
·····················|··································|·············|·············|·············|···············|··············
|  BondIssuer        ·  init                            ·          -  ·          -  ·     207959  ·          101  ·      46.88  │
·····················|··································|·············|·············|·············|···············|··············
|  BondIssuer        ·  transferOwnership               ·          -  ·          -  ·      36044  ·           10  ·       8.13  │
·····················|··································|·············|·············|·············|···············|··············
|  ERC20Upgradeable  ·  approve                         ·      29170  ·      48965  ·      47097  ·         1732  ·      10.62  │
·····················|··································|·············|·············|·············|···············|··············
|  ERC20Upgradeable  ·  transfer                        ·      37205  ·      67105  ·      59226  ·          211  ·      13.35  │
·····················|··································|·············|·············|·············|···············|··············
|  PerpetualTranche  ·  deposit                         ·     272554  ·     388016  ·     317474  ·          713  ·      71.56  │
·····················|··································|·············|·············|·············|···············|··············
|  PerpetualTranche  ·  pause                           ·          -  ·          -  ·      54154  ·            7  ·      12.21  │
·····················|··································|·············|·············|·············|···············|··············
|  PerpetualTranche  ·  redeem                          ·     103670  ·    1796283  ·     242656  ·           59  ·      54.70  │
·····················|··································|·············|·············|·············|···············|··············
|  PerpetualTranche  ·  transferERC20                   ·          -  ·          -  ·      67771  ·            1  ·      15.28  │
·····················|··································|·············|·············|·············|···············|··············
|  PerpetualTranche  ·  unpause                         ·          -  ·          -  ·      32276  ·            3  ·       7.28  │
·····················|··································|·············|·············|·············|···············|··············
|  PerpetualTranche  ·  updateState                     ·      63599  ·    1818972  ·     899919  ·          888  ·     202.86  │
·····················|··································|·············|·············|·············|···············|··············
|  PerpetualTranche  ·  updateTolerableTrancheMaturity  ·          -  ·          -  ·      42647  ·          101  ·       9.61  │
·····················|··································|·············|·············|·············|···············|··············
|  RolloverVault     ·  deploy                          ·     784791  ·    2014040  ·    1095471  ·          162  ·     246.94  │
·····················|··································|·············|·············|·············|···············|··············
|  RolloverVault     ·  deposit                         ·     120509  ·     286950  ·     273069  ·          788  ·      61.56  │
·····················|··································|·············|·············|·············|···············|··············
|  RolloverVault     ·  init                            ·     209868  ·     221974  ·     219892  ·          122  ·      49.57  │
·····················|··································|·············|·············|·············|···············|··············
|  RolloverVault     ·  recover                         ·     115361  ·     331052  ·     176129  ·           10  ·      39.70  │
·····················|··································|·············|·············|·············|···············|··············
|  RolloverVault     ·  recover                         ·      35286  ·    2977841  ·     301979  ·           48  ·      68.07  │
·····················|··································|·············|·············|·············|···············|··············
|  RolloverVault     ·  recoverAndRedeploy              ·          -  ·          -  ·     915881  ·           10  ·     206.46  │
·····················|··································|·············|·············|·············|···············|··············
|  RolloverVault     ·  updateMinDeploymentAmt          ·          -  ·          -  ·      53225  ·            3  ·      12.00  │
·····················|··································|·············|·············|·············|···············|··············
|  Deployments                                          ·                                         ·  % of limit   ·             │
························································|·············|·············|·············|···············|··············
|  BondIssuer                                           ·          -  ·          -  ·     946310  ·        3.2 %  ·     213.32  │
························································|·············|·············|·············|···············|··············
|  PerpetualTranche                                     ·          -  ·          -  ·    4025338  ·       13.4 %  ·     907.39  │
························································|·············|·············|·············|···············|··············
|  RolloverVault                                        ·          -  ·          -  ·    3913079  ·         13 %  ·     882.08  │
·-------------------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```

After

```
·-------------------------------------------------------|---------------------------|-------------|-----------------------------·
|                 Solc version: 0.8.19                  ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 30000000 gas  │
························································|···························|·············|······························
|  Methods                                              ·              123 gwei/gas               ·       1849.59 usd/eth       │
·····················|··································|·············|·············|·············|···············|··············
|  Contract          ·  Method                          ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
·····················|··································|·············|·············|·············|···············|··············
|  BondIssuer        ·  init                            ·          -  ·          -  ·     207959  ·          101  ·      47.31  │
·····················|··································|·············|·············|·············|···············|··············
|  BondIssuer        ·  transferOwnership               ·          -  ·          -  ·      36044  ·           10  ·       8.20  │
·····················|··································|·············|·············|·············|···············|··············
|  ERC20Upgradeable  ·  approve                         ·      29170  ·      48965  ·      47097  ·         1732  ·      10.71  │
·····················|··································|·············|·············|·············|···············|··············
|  ERC20Upgradeable  ·  transfer                        ·      37205  ·      67105  ·      59226  ·          211  ·      13.47  │
·····················|··································|·············|·············|·············|···············|··············
|  PerpetualTranche  ·  deposit                         ·     272554  ·     388016  ·     317476  ·          713  ·      72.23  │
·····················|··································|·············|·············|·············|···············|··············
|  PerpetualTranche  ·  pause                           ·          -  ·          -  ·      54154  ·            7  ·      12.32  │
·····················|··································|·············|·············|·············|···············|··············
|  PerpetualTranche  ·  redeem                          ·     103670  ·    1796283  ·     242656  ·           59  ·      55.20  │
·····················|··································|·············|·············|·············|···············|··············
|  PerpetualTranche  ·  transferERC20                   ·          -  ·          -  ·      67771  ·            1  ·      15.42  │
·····················|··································|·············|·············|·············|···············|··············
|  PerpetualTranche  ·  unpause                         ·          -  ·          -  ·      32276  ·            3  ·       7.34  │
·····················|··································|·············|·············|·············|···············|··············
|  PerpetualTranche  ·  updateState                     ·      63599  ·    1818972  ·     899919  ·          888  ·     204.73  │
·····················|··································|·············|·············|·············|···············|··············
|  PerpetualTranche  ·  updateTolerableTrancheMaturity  ·          -  ·          -  ·      42647  ·          101  ·       9.70  │
·····················|··································|·············|·············|·············|···············|··············
|  RolloverVault     ·  deploy                          ·     784791  ·    2014040  ·    1074968  ·          157  ·     244.55  │
·····················|··································|·············|·············|·············|···············|··············
|  RolloverVault     ·  deposit                         ·     120509  ·     286950  ·     273069  ·          788  ·      62.12  │
·····················|··································|·············|·············|·············|···············|··············
|  RolloverVault     ·  init                            ·     209880  ·     221974  ·     219892  ·          122  ·      50.03  │
·····················|··································|·············|·············|·············|···············|··············
|  RolloverVault     ·  recover                         ·     115295  ·     307527  ·     157797  ·            9  ·      35.90  │
·····················|··································|·············|·············|·············|···············|··············
|  RolloverVault     ·  recover                         ·      35286  ·    2418256  ·     263391  ·           48  ·      59.92  │
·····················|··································|·············|·············|·············|···············|··············
|  RolloverVault     ·  recoverAndRedeploy              ·          -  ·          -  ·     885534  ·           10  ·     201.46  │
·····················|··································|·············|·············|·············|···············|··············
|  RolloverVault     ·  updateMinDeploymentAmt          ·          -  ·          -  ·      53225  ·            3  ·      12.11  │
·····················|··································|·············|·············|·············|···············|··············
|  Deployments                                          ·                                         ·  % of limit   ·             │
························································|·············|·············|·············|···············|··············
|  BondIssuer                                           ·          -  ·          -  ·     946310  ·        3.2 %  ·     215.29  │
························································|·············|·············|·············|···············|··············
|  PerpetualTranche                                     ·          -  ·          -  ·    4025338  ·       13.4 %  ·     915.76  │
························································|·············|·············|·············|···············|··············
|  RolloverVault                                        ·          -  ·          -  ·    4003702  ·       13.3 %  ·     910.84  │
·-------------------------------------------------------|-------------|-------------|-------------|---------------|-------------·


```