### PR TITLE
Added perp redemption to vault recovery flow

### DIFF
--- a/spot-contracts/contracts/PerpetualTranche.sol
+++ b/spot-contracts/contracts/PerpetualTranche.sol
@@ -613,14 +613,14 @@ contract PerpetualTranche is
         ITranche trancheIn,
         IERC20Upgradeable tokenOut,
         uint256 trancheInAmtAvailable
-    ) external override onlyRollers nonReentrant whenNotPaused afterStateUpdate returns (RolloverPreview memory) {
+    ) external override onlyRollers nonReentrant whenNotPaused afterStateUpdate returns (RolloverData memory) {
         // verifies if rollover is acceptable
         if (!_isAcceptableRollover(trancheIn, tokenOut)) {
             revert UnacceptableRollover(trancheIn, tokenOut);
         }
 
         // calculates the perp denominated amount rolled over and the tokenOutAmt
-        IPerpetualTranche.RolloverPreview memory r = _computeRolloverAmt(
+        IPerpetualTranche.RolloverData memory r = _computeRolloverAmt(
             trancheIn,
             tokenOut,
             trancheInAmtAvailable,
@@ -778,7 +778,7 @@ contract PerpetualTranche is
         IERC20Upgradeable tokenOut,
         uint256 trancheInAmtAvailable,
         uint256 tokenOutAmtRequested
-    ) external override afterStateUpdate returns (IPerpetualTranche.RolloverPreview memory) {
+    ) external override afterStateUpdate returns (IPerpetualTranche.RolloverData memory) {
         return _computeRolloverAmt(trancheIn, tokenOut, trancheInAmtAvailable, tokenOutAmtRequested);
     }
 
@@ -944,8 +944,8 @@ contract PerpetualTranche is
         IERC20Upgradeable tokenOut,
         uint256 trancheInAmtAvailable,
         uint256 tokenOutAmtRequested
-    ) private view returns (IPerpetualTranche.RolloverPreview memory) {
-        IPerpetualTranche.RolloverPreview memory r;
+    ) private view returns (IPerpetualTranche.RolloverData memory) {
+        IPerpetualTranche.RolloverData memory r;
 
         uint256 trancheInDiscount = computeDiscount(trancheIn);
         uint256 trancheOutDiscount = computeDiscount(tokenOut);

--- a/spot-contracts/contracts/RouterV1.sol
+++ b/spot-contracts/contracts/RouterV1.sol
@@ -121,14 +121,11 @@ contract RouterV1 {
 
         for (uint8 i = 0; i < bt.tranches.length; i++) {
             uint256 trancheAmt = bt.tranches[i].balanceOf(address(this));
-            uint256 mintAmt = perp.computeMintAmt(bt.tranches[i], trancheAmt);
-            if (mintAmt > 0) {
-                // approves tranches to be spent
-                _checkAndApproveMax(bt.tranches[i], address(perp), trancheAmt);
-
-                // mints perp tokens using tranches
-                perp.deposit(bt.tranches[i], trancheAmt);
-            } else {
+            // approves tranches to be spent
+            _checkAndApproveMax(bt.tranches[i], address(perp), trancheAmt);
+            // mints perp tokens using tranches
+            uint256 mintAmt = perp.deposit(bt.tranches[i], trancheAmt);
+            if (mintAmt <= 0) {
                 // transfers unused tranches back
                 bt.tranches[i].safeTransfer(msg.sender, trancheAmt);
             }

--- a/spot-contracts/contracts/RouterV1.sol
+++ b/spot-contracts/contracts/RouterV1.sol
@@ -197,12 +197,12 @@ contract RouterV1 {
         external
         afterPerpStateUpdate(perp)
         returns (
-            IPerpetualTranche.RolloverPreview memory,
+            IPerpetualTranche.RolloverData memory,
             IERC20Upgradeable,
             int256
         )
     {
-        IPerpetualTranche.RolloverPreview memory r;
+        IPerpetualTranche.RolloverData memory r;
         r.remainingTrancheInAmt = trancheInAmtRequested;
 
         IERC20Upgradeable feeToken = perp.feeToken();

--- a/spot-contracts/contracts/_interfaces/IPerpetualTranche.sol
+++ b/spot-contracts/contracts/_interfaces/IPerpetualTranche.sol
@@ -38,15 +38,18 @@ interface IPerpetualTranche is IERC20Upgradeable {
     /// @notice Deposits tranche tokens into the system and mint perp tokens.
     /// @param trancheIn The address of the tranche token to be deposited.
     /// @param trancheInAmt The amount of tranche tokens deposited.
+    /// @return The amount of perp tokens minted.
     function deposit(ITranche trancheIn, uint256 trancheInAmt) external returns (uint256);
 
     /// @notice Burn perp tokens and redeem the share of reserve assets.
     /// @param perpAmtBurnt The amount of perp tokens burnt from the caller.
+    /// @return tokensOut The list of reserve tokens redeemed.
+    /// @return tokenOutAmts The list of reserve token amounts redeemed.
     function redeem(uint256 perpAmtBurnt)
         external
         returns (IERC20Upgradeable[] memory tokensOut, uint256[] memory tokenOutAmts);
 
-    struct RolloverPreview {
+    struct RolloverData {
         /// @notice The perp denominated value of tokens rolled over.
         uint256 perpRolloverAmt;
         /// @notice The amount of tokens rolled out.
@@ -66,11 +69,12 @@ interface IPerpetualTranche is IERC20Upgradeable {
     /// @param trancheIn The tranche token deposited.
     /// @param tokenOut The reserve token to be redeemed.
     /// @param trancheInAmt The amount of trancheIn tokens deposited.
+    /// @return r The rollover amounts in various denominations.
     function rollover(
         ITranche trancheIn,
         IERC20Upgradeable tokenOut,
         uint256 trancheInAmt
-    ) external returns (RolloverPreview memory);
+    ) external returns (RolloverData memory r);
 
     /// @notice Reference to the wallet or contract that has the ability to pause/unpause operations.
     /// @return The address of the keeper.
@@ -179,7 +183,7 @@ interface IPerpetualTranche is IERC20Upgradeable {
         IERC20Upgradeable tokenOut,
         uint256 trancheInAmtAvailable,
         uint256 tokenOutAmtRequested
-    ) external returns (RolloverPreview memory);
+    ) external returns (RolloverData memory r);
 
     /// @notice The discount to be applied given the reserve token.
     /// @param token The address of the reserve token.

--- a/spot-contracts/contracts/_interfaces/IPerpetualTranche.sol
+++ b/spot-contracts/contracts/_interfaces/IPerpetualTranche.sol
@@ -38,11 +38,29 @@ interface IPerpetualTranche is IERC20Upgradeable {
     /// @notice Deposits tranche tokens into the system and mint perp tokens.
     /// @param trancheIn The address of the tranche token to be deposited.
     /// @param trancheInAmt The amount of tranche tokens deposited.
-    function deposit(ITranche trancheIn, uint256 trancheInAmt) external;
+    function deposit(ITranche trancheIn, uint256 trancheInAmt) external returns (uint256);
 
     /// @notice Burn perp tokens and redeem the share of reserve assets.
     /// @param perpAmtBurnt The amount of perp tokens burnt from the caller.
-    function redeem(uint256 perpAmtBurnt) external;
+    function redeem(uint256 perpAmtBurnt)
+        external
+        returns (IERC20Upgradeable[] memory tokensOut, uint256[] memory tokenOutAmts);
+
+    struct RolloverPreview {
+        /// @notice The perp denominated value of tokens rolled over.
+        uint256 perpRolloverAmt;
+        /// @notice The amount of tokens rolled out.
+        uint256 tokenOutAmt;
+        /// @notice The tranche denominated amount of tokens rolled out.
+        /// @dev tokenOutAmt and trancheOutAmt can only be different values
+        ///      in the case of rolling over the mature tranche.
+        uint256 trancheOutAmt;
+        /// @notice The amount of trancheIn tokens rolled in.
+        uint256 trancheInAmt;
+        /// @notice The difference between the available trancheIn amount and
+        ///        the amount of tokens used for the rollover.
+        uint256 remainingTrancheInAmt;
+    }
 
     /// @notice Rotates newer tranches in for reserve tokens.
     /// @param trancheIn The tranche token deposited.
@@ -52,7 +70,7 @@ interface IPerpetualTranche is IERC20Upgradeable {
         ITranche trancheIn,
         IERC20Upgradeable tokenOut,
         uint256 trancheInAmt
-    ) external;
+    ) external returns (RolloverPreview memory);
 
     /// @notice Reference to the wallet or contract that has the ability to pause/unpause operations.
     /// @return The address of the keeper.
@@ -148,22 +166,6 @@ interface IPerpetualTranche is IERC20Upgradeable {
     function computeRedemptionAmts(uint256 perpAmtBurnt)
         external
         returns (IERC20Upgradeable[] memory tokensOut, uint256[] memory tokenOutAmts);
-
-    struct RolloverPreview {
-        /// @notice The perp denominated value of tokens rolled over.
-        uint256 perpRolloverAmt;
-        /// @notice The amount of tokens rolled out.
-        uint256 tokenOutAmt;
-        /// @notice The tranche denominated amount of tokens rolled out.
-        /// @dev tokenOutAmt and trancheOutAmt can only be different values
-        ///      in the case of rolling over the mature tranche.
-        uint256 trancheOutAmt;
-        /// @notice The amount of trancheIn tokens rolled in.
-        uint256 trancheInAmt;
-        /// @notice The difference between the available trancheIn amount and
-        ///        the amount of tokens used for the rollover.
-        uint256 remainingTrancheInAmt;
-    }
 
     /// @notice Computes the amount reserve tokens that are rolled out for the given number
     ///         of `trancheIn` tokens rolled in.

--- a/spot-contracts/contracts/vaults/RolloverVault.sol
+++ b/spot-contracts/contracts/vaults/RolloverVault.sol
@@ -27,7 +27,8 @@ error OutOfBounds();
  *                 to get tranche tokens in return, it then swaps these fresh tranche tokens for
  *                 older tranche tokens (ones mature or approaching maturity) from perp.
  *                 system through a rollover operation and earns an income in perp tokens.
- *              2) recover: The vault redeems tranches for the underlying asset.
+ *              2) recover: The vault redeems 1) perps for their underlying tranches and the
+ *                          2) tranches it holds for the underlying asset.
  *                 NOTE: It performs both mature and immature redemption. Read more: https://bit.ly/3tuN6OC
  *
  *
@@ -185,6 +186,25 @@ contract RolloverVault is
 
     /// @inheritdoc IVault
     function recover() public override nonReentrant whenNotPaused {
+        // Redeem perp for tranches
+        uint256 perpBalance = perp.balanceOf(address(this));
+        if (perpBalance > 0) {
+            (IERC20Upgradeable[] memory tranchesRedeemed, ) = perp.computeRedemptionAmts(perpBalance);
+            perp.redeem(perpBalance);
+
+            // sync underlying
+            // require(tranchesRedeemed[0] == underlying);
+            _syncAsset(underlying);
+
+            // sync new tranches
+            for (uint256 i = 1; i < tranchesRedeemed.length; i++) {
+                _syncAndAddDeployedAsset(tranchesRedeemed[i]);
+            }
+            // sync perp
+            _syncAsset(perp);
+        }
+
+        // Redeem deployed tranches
         uint256 deployedCount_ = _deployed.length();
         if (deployedCount_ <= 0) {
             return;

--- a/spot-contracts/contracts/vaults/RolloverVault.sol
+++ b/spot-contracts/contracts/vaults/RolloverVault.sol
@@ -500,7 +500,7 @@ contract RolloverVault is
 
             // Perform rollover
             _checkAndApproveMax(trancheIntoPerp, address(perp_), trancheInAmtAvailable);
-            IPerpetualTranche.RolloverPreview memory rd = perp_.rollover(
+            IPerpetualTranche.RolloverData memory rd = perp_.rollover(
                 trancheIntoPerp,
                 tokenOutOfPerp,
                 trancheInAmtAvailable


### PR DESCRIPTION
- As part of the batch recovery, we first redeem the earned perp tokens for the underlying tranches and then continue with the existing flow.
- Updated perp methods "deposit", "redeem" and "rollover" to return data about the operation.