### PR TITLE
Fixed rounding issue with recovery

### DIFF
--- a/spot-contracts/test/helpers.ts
+++ b/spot-contracts/test/helpers.ts
@@ -10,9 +10,10 @@ const TOKEN_DECIMALS = 18;
 const PRICE_DECIMALS = 8;
 const DISCOUNT_DECIMALS = 18;
 
-export const toFixedPtAmt = (a: string): BigNumber => utils.parseUnits(a, TOKEN_DECIMALS);
-export const toPriceFixedPtAmt = (a: string): BigNumber => utils.parseUnits(a, PRICE_DECIMALS);
-export const toDiscountFixedPtAmt = (a: string): BigNumber => utils.parseUnits(a, DISCOUNT_DECIMALS);
+const sciParseFloat = (a: string): BigNumber => (a.includes("e") ? parseFloat(a).toFixed(18) : a);
+export const toFixedPtAmt = (a: string): BigNumber => utils.parseUnits(sciParseFloat(a), TOKEN_DECIMALS);
+export const toPriceFixedPtAmt = (a: string): BigNumber => utils.parseUnits(sciParseFloat(a), PRICE_DECIMALS);
+export const toDiscountFixedPtAmt = (a: string): BigNumber => utils.parseUnits(sciParseFloat(a), DISCOUNT_DECIMALS);
 
 const ORACLE_BASE_PRICE = toPriceFixedPtAmt("1");
 


### PR DESCRIPTION
The `computeRedeemableTrancheAmounts` should round the balances down to a number divisible by the tranche ratio. 

For example, if the tranche balances are "10, 15, 7.461048491123254231" the previous implementation returned "2.984419396449301692, 4.476629094673952538, 7.461048491123254231".

However, this is not the right redemption ratio, which is expected to be precisely divisible. 
https://github.com/buttonwood-protocol/tranche/blob/main/contracts/BondController.sol#L229

The proposed change rounds down to achieve amounts are consistent with the expected tranche ratio. 
We get -> "2.984419396449301600, 4.476629094673952400, 7.461048491123254000"