### PR TITLE
Audit fixes - 2nd pass

### DIFF
--- a/spot-contracts/contracts/PerpetualTranche.sol
+++ b/spot-contracts/contracts/PerpetualTranche.sol
@@ -909,7 +909,8 @@ contract PerpetualTranche is
     function _reserveValue() private view returns (uint256) {
         IERC20Upgradeable underlying_ = _reserveAt(0);
         uint256 totalVal = underlying_.balanceOf(address(this));
-        for (uint256 i = 1; i < _reserves.length(); i++) {
+        uint256 reserveCount = _reserves.length();
+        for (uint256 i = 1; i < reserveCount; i++) {
             ITranche tranche = ITranche(address(_reserveAt(i)));
             IBondController parentBond = IBondController(tranche.bond());
             totalVal += _computeReserveTrancheValue(

--- a/spot-contracts/contracts/PerpetualTranche.sol
+++ b/spot-contracts/contracts/PerpetualTranche.sol
@@ -5,7 +5,7 @@ import { IERC20MetadataUpgradeable } from "@openzeppelin/contracts-upgradeable/t
 import { IERC20Upgradeable, IPerpetualTranche, IBondIssuer, IFeePolicy, IBondController, ITranche } from "./_interfaces/IPerpetualTranche.sol";
 import { IRolloverVault } from "./_interfaces/IRolloverVault.sol";
 import { TokenAmount, RolloverData, SubscriptionParams } from "./_interfaces/CommonTypes.sol";
-import { UnauthorizedCall, UnauthorizedTransferOut, UnexpectedDecimals, UnexpectedAsset, UnacceptableParams, UnacceptableRollover, ExceededMaxSupply, ExceededMaxMintPerTranche } from "./_interfaces/ProtocolErrors.sol";
+import { UnauthorizedCall, UnauthorizedTransferOut, UnexpectedDecimals, UnexpectedAsset, UnacceptableParams, UnacceptableRollover, ExceededMaxSupply, ExceededMaxMintPerTranche, ReserveCountOverLimit } from "./_interfaces/ProtocolErrors.sol";
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
@@ -110,6 +110,9 @@ contract PerpetualTranche is
     // Number of decimals for a multiplier of 1.0x (i.e. 100%)
     uint8 public constant FEE_POLICY_DECIMALS = 8;
     uint256 public constant FEE_ONE = (10 ** FEE_POLICY_DECIMALS);
+
+    /// @dev The maximum number of reserve assets that can be held by perp.
+    uint8 public constant MAX_RESERVE_COUNT = 11;
 
     //-------------------------------------------------------------------------
     // Storage
@@ -390,7 +393,7 @@ contract PerpetualTranche is
         _burn(msg.sender, perpAmtBurnt);
 
         // transfers reserve tokens out
-        for (uint256 i = 0; i < tokensOut.length; i++) {
+        for (uint8 i = 0; i < tokensOut.length; i++) {
             if (tokensOut[i].amount > 0) {
                 _transferOutOfReserve(msg.sender, tokensOut[i].token, tokensOut[i].amount);
             }
@@ -481,22 +484,35 @@ contract PerpetualTranche is
     }
 
     /// @inheritdoc IPerpetualTranche
-    /// @dev Reserve tokens which are not up for rollover are marked by `address(0)`.
     function getReserveTokensUpForRollover() external override afterStateUpdate returns (IERC20Upgradeable[] memory) {
-        uint256 reserveCount = _reserves.length();
-        IERC20Upgradeable[] memory rolloverTokens = new IERC20Upgradeable[](reserveCount);
+        uint8 reserveCount = uint8(_reserves.length());
+        IERC20Upgradeable[] memory activeRolloverTokens = new IERC20Upgradeable[](reserveCount);
+
+        // We count the number of tokens up for rollover.
+        uint8 numTokensUpForRollover = 0;
 
         // If any underlying collateral exists it can be rolled over.
         IERC20Upgradeable underlying_ = _reserveAt(0);
         if (underlying_.balanceOf(address(this)) > 0) {
-            rolloverTokens[0] = underlying_;
+            activeRolloverTokens[0] = underlying_;
+            numTokensUpForRollover++;
         }
 
-        // Iterating through the reserve to find tranches that are no longer "acceptable"
-        for (uint256 i = 1; i < reserveCount; i++) {
+        // Iterating through the reserve to find tranches that are ready to be rolled out.
+        for (uint8 i = 1; i < reserveCount; i++) {
             IERC20Upgradeable token = _reserveAt(i);
             if (_isTimeForRollout(ITranche(address(token)))) {
-                rolloverTokens[i] = token;
+                activeRolloverTokens[i] = token;
+                numTokensUpForRollover++;
+            }
+        }
+
+        // We recreate a smaller array with just the tokens up for rollover.
+        IERC20Upgradeable[] memory rolloverTokens = new IERC20Upgradeable[](numTokensUpForRollover);
+        uint8 j = 0;
+        for (uint8 i = 0; i < reserveCount; i++) {
+            if (address(activeRolloverTokens[i]) != address(0)) {
+                rolloverTokens[j++] = activeRolloverTokens[i];
             }
         }
 
@@ -565,8 +581,8 @@ contract PerpetualTranche is
         //       end of the set and removing the last element.
         //       We also skip the `reserveAt(0)`, i.e) the underlying collateral,
         //       which is never removed.
-        uint256 reserveCount = _reserves.length();
-        for (uint256 i = reserveCount - 1; i > 0; i--) {
+        uint8 reserveCount = uint8(_reserves.length());
+        for (uint8 i = reserveCount - 1; i > 0; i--) {
             ITranche tranche = ITranche(address(_reserveAt(i)));
             IBondController bond = IBondController(tranche.bond());
 
@@ -640,6 +656,10 @@ contract PerpetualTranche is
         if (balance > 0 && !inReserve_) {
             // Inserts new tranche into reserve set.
             _reserves.add(address(token));
+
+            if (_reserves.length() > MAX_RESERVE_COUNT) {
+                revert ReserveCountOverLimit();
+            }
         } else if (balance <= 0 && inReserve_) {
             // Removes tranche from reserve set.
             _reserves.remove(address(token));
@@ -712,9 +732,9 @@ contract PerpetualTranche is
         //-----------------------------------------------------------------------------
 
         // Compute redemption amounts
-        uint256 reserveCount = _reserves.length();
+        uint8 reserveCount = uint8(_reserves.length());
         TokenAmount[] memory reserveTokens = new TokenAmount[](reserveCount);
-        for (uint256 i = 0; i < reserveCount; i++) {
+        for (uint8 i = 0; i < reserveCount; i++) {
             IERC20Upgradeable tokenOut = _reserveAt(i);
             reserveTokens[i] = TokenAmount({
                 token: tokenOut,
@@ -909,8 +929,8 @@ contract PerpetualTranche is
     function _reserveValue() private view returns (uint256) {
         IERC20Upgradeable underlying_ = _reserveAt(0);
         uint256 totalVal = underlying_.balanceOf(address(this));
-        uint256 reserveCount = _reserves.length();
-        for (uint256 i = 1; i < reserveCount; i++) {
+        uint8 reserveCount = uint8(_reserves.length());
+        for (uint8 i = 1; i < reserveCount; i++) {
             ITranche tranche = ITranche(address(_reserveAt(i)));
             IBondController parentBond = IBondController(tranche.bond());
             totalVal += _computeReserveTrancheValue(

--- a/spot-contracts/contracts/PerpetualTranche.sol
+++ b/spot-contracts/contracts/PerpetualTranche.sol
@@ -418,7 +418,7 @@ contract PerpetualTranche is
         RolloverData memory r = _computeRolloverAmt(trancheIn, tokenOut, trancheInAmtAvailable);
 
         // Verifies if rollover amount is acceptable
-        if (r.trancheInAmt <= 0) {
+        if (r.trancheInAmt <= 0 || r.tokenOutAmt <= 0) {
             return r;
         }
 

--- a/spot-contracts/contracts/PerpetualTranche.sol
+++ b/spot-contracts/contracts/PerpetualTranche.sol
@@ -495,7 +495,7 @@ contract PerpetualTranche is
         // Iterating through the reserve to find tranches that are no longer "acceptable"
         for (uint256 i = 1; i < reserveCount; i++) {
             IERC20Upgradeable token = _reserveAt(i);
-            if (_isReadyForRollout(ITranche(address(token)))) {
+            if (_isTimeForRollout(ITranche(address(token)))) {
                 rolloverTokens[i] = token;
             }
         }
@@ -835,17 +835,17 @@ contract PerpetualTranche is
 
         // when rolling out a normal tranche
         ITranche trancheOut = ITranche(address(tokenOut));
-        return (_inReserve(trancheOut) &&
-            _isDepositTranche(trancheIn) &&
+        return (_isDepositTranche(trancheIn) &&
+            _inReserve(trancheOut) &&
             !_isDepositTranche(trancheOut) &&
-            _isReadyForRollout(trancheOut));
+            _isTimeForRollout(trancheOut));
     }
 
     /// @dev Checks if the given bond is valid and can be accepted into the reserve.
     ///      * Expects the bond to to have the same collateral token as perp.
     ///      * Expects the bond to have only two tranches.
     ///      * Expects the bond controller to not withhold any fees.
-    ///      * Expects the bond's duration to be within the max safety bound.
+    ///      * Expects the bond's time to maturity to be within the max safety bound.
     ///      * Expects the bond's senior and junior tranches to point back to the bond.
     /// @return True if the bond is valid.
     function _isValidDepositBond(IBondController bond) private view returns (bool) {
@@ -859,7 +859,7 @@ contract PerpetualTranche is
 
     /// @dev Checks if the given tranche's parent bond's time remaining to maturity is less than `minTrancheMaturitySec`.
     /// @return True if the tranche can be rolled out of perp.
-    function _isReadyForRollout(ITranche tranche) private view returns (bool) {
+    function _isTimeForRollout(ITranche tranche) private view returns (bool) {
         // NOTE: `secondsToMaturity` will be 0 if the bond is past maturity.
         return (IBondController(tranche.bond()).secondsToMaturity() <= minTrancheMaturitySec);
     }

--- a/spot-contracts/contracts/RolloverVault.sol
+++ b/spot-contracts/contracts/RolloverVault.sol
@@ -468,10 +468,7 @@ contract RolloverVault is
 
         // Revert if swapping reduces the underlying balance of the vault below the bounds.
         uint256 underlyingBal = underlying_.balanceOf(address(this));
-        if (
-            underlyingBal <= minUnderlyingBal ||
-            underlyingBal.mulDiv(ONE, s.vaultTVL) <= minUnderlyingPerc
-        ) {
+        if (underlyingBal <= minUnderlyingBal || underlyingBal.mulDiv(ONE, s.vaultTVL) <= minUnderlyingPerc) {
             revert UnacceptableSwap();
         }
 
@@ -486,10 +483,7 @@ contract RolloverVault is
         // Calculates the fee adjusted underlying amount to transfer to the user.
         IPerpetualTranche perp_ = perp;
         IERC20Upgradeable underlying_ = underlying;
-        (
-            uint256 underlyingAmtOut,
-            uint256 perpFeeAmtToBurn,
-        ) = computePerpToUnderlyingSwapAmt(perpAmtIn);
+        (uint256 underlyingAmtOut, uint256 perpFeeAmtToBurn, ) = computePerpToUnderlyingSwapAmt(perpAmtIn);
 
         // Revert if insufficient tokens are swapped in or out
         if (underlyingAmtOut <= 0 || perpAmtIn <= 0) {
@@ -844,9 +838,6 @@ contract RolloverVault is
         for (uint256 i = 0; (i < rolloverTokens.length && trancheInAmtAvailable > 0); i++) {
             // tokenOutOfPerp is the reserve token coming out of perp into the vault
             IERC20Upgradeable tokenOutOfPerp = rolloverTokens[i];
-            if (address(tokenOutOfPerp) == address(0)) {
-                continue;
-            }
 
             // Perform rollover
             RolloverData memory r = perp_.rollover(trancheIntoPerp, tokenOutOfPerp, trancheInAmtAvailable);

--- a/spot-contracts/contracts/RouterV2.sol
+++ b/spot-contracts/contracts/RouterV2.sol
@@ -52,6 +52,11 @@ contract RouterV2 {
     /// @param bond Address of the deposit bond.
     /// @param collateralAmount The amount of collateral the user wants to tranche.
     function trancheAndDeposit(IPerpetualTranche perp, IBondController bond, uint256 collateralAmount) external {
+        // If deposit bond does not exist, we first issue it.
+        if (address(bond).code.length <= 0) {
+            perp.updateState();
+        }
+
         BondTranches memory bt = bond.getTranches();
         IERC20Upgradeable collateralToken = IERC20Upgradeable(bond.collateralToken());
 

--- a/spot-contracts/contracts/_interfaces/ProtocolErrors.sol
+++ b/spot-contracts/contracts/_interfaces/ProtocolErrors.sol
@@ -49,8 +49,8 @@ error ExceededMaxMintPerTranche();
 //-------------------------------------------------------------------------
 // Vault
 
-/// @notice Expected the operation not to decrease the system's tvl.
-error TVLDecreased();
+/// @notice Expected more underlying token liquidity to perform operation.
+error InsufficientLiquidity();
 
 /// @notice Expected to swap non-zero assets.
 error UnacceptableSwap();

--- a/spot-contracts/contracts/_interfaces/ProtocolErrors.sol
+++ b/spot-contracts/contracts/_interfaces/ProtocolErrors.sol
@@ -63,3 +63,18 @@ error DeployedCountOverLimit();
 
 /// @notice Expected parent bond to have only 2 children tranches.
 error UnacceptableTrancheLength();
+
+//-------------------------------------------------------------------------
+// Fee Policy
+
+/// @notice Expected perc value to be at most (1 * 10**DECIMALS), i.e) 1.0 or 100%.
+error InvalidPerc();
+
+/// @notice Expected target subscription ratio to be within defined bounds.
+error InvalidTargetSRBounds();
+
+/// @notice Expected deviation ratio bounds to be valid.
+error InvalidDRBounds();
+
+/// @notice Expected sigmoid asymptotes to be within defined bounds.
+error InvalidSigmoidAsymptotes();

--- a/spot-contracts/contracts/_interfaces/ProtocolErrors.sol
+++ b/spot-contracts/contracts/_interfaces/ProtocolErrors.sol
@@ -31,6 +31,9 @@ error UnacceptableParams();
 /// @notice Storage array access out of bounds.
 error OutOfBounds();
 
+/// @notice Expected the number of reserve assets to be under the limit.
+error ReserveCountOverLimit();
+
 //-------------------------------------------------------------------------
 // Perp
 

--- a/spot-contracts/contracts/_utils/BondHelpers.sol
+++ b/spot-contracts/contracts/_utils/BondHelpers.sol
@@ -59,7 +59,7 @@ library BondHelpers {
     /// @return t The senior tranche address.
     function getSeniorTranche(IBondController b) internal view returns (ITranche t) {
         (t, ) = b.tranches(0);
-        return (t);
+        return t;
     }
 
     /// @notice Given a bond, returns the tranche ratio of the most senior tranche.

--- a/spot-contracts/contracts/_utils/BondHelpers.sol
+++ b/spot-contracts/contracts/_utils/BondHelpers.sol
@@ -34,7 +34,6 @@ library BondHelpers {
     }
 
     /// @notice Given a bond, retrieves all of the bond's tranches.
-    /// @notice Given a bond, retrieves all of the bond's tranches.
     /// @param b The address of the bond contract.
     /// @return bt The bond's tranche data.
     function getTranches(IBondController b) internal view returns (BondTranches memory bt) {

--- a/spot-contracts/contracts/_utils/BondHelpers.sol
+++ b/spot-contracts/contracts/_utils/BondHelpers.sol
@@ -42,7 +42,6 @@ library BondHelpers {
         }
         (bt.tranches[0], bt.trancheRatios[0]) = b.tranches(0);
         (bt.tranches[1], bt.trancheRatios[1]) = b.tranches(1);
-        return bt;
     }
 
     /// @notice Given a bond, returns the tranche at the specified index.
@@ -51,7 +50,6 @@ library BondHelpers {
     /// @return t The tranche address.
     function trancheAt(IBondController b, uint8 i) internal view returns (ITranche t) {
         (t, ) = b.tranches(i);
-        return t;
     }
 
     /// @notice Given a bond, returns the address of the most senior tranche.
@@ -59,15 +57,13 @@ library BondHelpers {
     /// @return t The senior tranche address.
     function getSeniorTranche(IBondController b) internal view returns (ITranche t) {
         (t, ) = b.tranches(0);
-        return t;
     }
 
     /// @notice Given a bond, returns the tranche ratio of the most senior tranche.
     /// @param b The address of the bond contract.
-    /// @return seniorRatio The tranche ratio of the senior most tranche.
-    function getSeniorTrancheRatio(IBondController b) internal view returns (uint256) {
-        (, uint256 r) = b.tranches(0);
-        return r;
+    /// @return r The tranche ratio of the senior most tranche.
+    function getSeniorTrancheRatio(IBondController b) internal view returns (uint256 r) {
+        (, r) = b.tranches(0);
     }
 
     /// @notice Helper function to estimate the amount of tranches minted when a given amount of collateral

--- a/spot-contracts/test/RouterV2.ts
+++ b/spot-contracts/test/RouterV2.ts
@@ -76,10 +76,10 @@ describe("RouterV2", function () {
     it("should compute the tranche amounts", async function () {
       const r = await router.callStatic.previewTranche(perp.address, toFixedPtAmt("1000"));
       expect(r[0]).to.eq(await perp.callStatic.getDepositBond());
-      expect(r[1][0]).to.eq(depositTranches[0].address);
-      expect(r[1][1]).to.eq(depositTranches[1].address);
-      expect(r[2][0]).to.eq(toFixedPtAmt("200"));
-      expect(r[2][1]).to.eq(toFixedPtAmt("800"));
+      expect(r[1][0].token).to.eq(depositTranches[0].address);
+      expect(r[1][0].amount).to.eq(toFixedPtAmt("200"));
+      expect(r[1][1].token).to.eq(depositTranches[1].address);
+      expect(r[1][1].amount).to.eq(toFixedPtAmt("800"));
     });
   });
 

--- a/spot-contracts/test/RouterV2.ts
+++ b/spot-contracts/test/RouterV2.ts
@@ -9,6 +9,7 @@ import {
   getTranches,
   toFixedPtAmt,
   advancePerpQueue,
+  advanceTime,
   mintCollteralToken,
 } from "./helpers";
 use(smock.matchers);
@@ -98,6 +99,18 @@ describe("RouterV2", function () {
         await expect(
           router.trancheAndDeposit(perp.address, depositBond.address, toFixedPtAmt("1000")),
         ).to.revertedWithCustomError(perp, "UnexpectedAsset");
+      });
+    });
+
+    describe("when deposit bond is not issued", function () {
+      beforeEach(async function () {
+        await collateralToken.approve(router.address, constants.MaxUint256);
+        await advanceTime(7200);
+      });
+      it("should not revert", async function () {
+        const depositBond = await bondAt(await perp.callStatic.getDepositBond());
+        await expect(router.trancheAndDeposit(perp.address, depositBond.address, toFixedPtAmt("1000"))).not.to.be
+          .reverted;
       });
     });
 

--- a/spot-contracts/test/helpers.ts
+++ b/spot-contracts/test/helpers.ts
@@ -267,7 +267,7 @@ export const getReserveTokens = async (perp: Contract) => {
 export const logVaultAssets = async (vault: Contract) => {
   const ERC20 = await ethers.getContractFactory("MockERC20");
   const count = await vault.assetCount();
-  const deployedCount = await vault.deployedCount();
+  const assetCount = await vault.assetCount();
   console.log("Asset count", count);
 
   const underlying = await ERC20.attach(await vault.underlying());
@@ -276,8 +276,8 @@ export const logVaultAssets = async (vault: Contract) => {
     underlying.address,
     utils.formatUnits(await vault.vaultAssetBalance(underlying.address), await underlying.decimals()),
   );
-  for (let i = 0; i < deployedCount; i++) {
-    const token = await ERC20.attach(await vault.deployedAt(i));
+  for (let i = 1; i < assetCount; i++) {
+    const token = await ERC20.attach(await vault.assetAt(i));
     console.log(
       i + 1,
       token.address,
@@ -296,9 +296,8 @@ export const checkVaultAssetComposition = async (vault: Contract, tokens: Contra
 export const getVaultAssets = async (vault: Contract) => {
   const ERC20 = await ethers.getContractFactory("MockERC20");
   const assets: Contract[] = [];
-  assets.push(await ERC20.attach(await vault.underlying()));
-  for (let i = 0; i < (await vault.deployedCount()); i++) {
-    assets.push(await ERC20.attach(await vault.deployedAt(i)));
+  for (let i = 0; i < (await vault.assetCount()); i++) {
+    assets.push(await ERC20.attach(await vault.assetAt(i)));
   }
   return assets;
 };

--- a/spot-contracts/test/helpers.ts
+++ b/spot-contracts/test/helpers.ts
@@ -185,6 +185,10 @@ export const getDepositBond = async (perp: Contract): Contract => {
   return bondAt(await perp.callStatic.getDepositBond());
 };
 
+export const advanceTime = async (time: number): Promise<Transaction> => {
+  return TimeHelpers.increaseTime(time);
+};
+
 export const advancePerpQueue = async (perp: Contract, time: number): Promise<Transaction> => {
   await TimeHelpers.increaseTime(time);
   return perp.updateState();

--- a/spot-contracts/test/perp/PerpetualTranche.ts
+++ b/spot-contracts/test/perp/PerpetualTranche.ts
@@ -194,11 +194,6 @@ describe("PerpetualTranche", function () {
       it("should update reference", async function () {
         expect(await perp.keeper()).to.eq(await otherUser.getAddress());
       });
-      it("should emit event", async function () {
-        await expect(tx)
-          .to.emit(perp, "UpdatedKeeper")
-          .withArgs(constants.AddressZero, await otherUser.getAddress());
-      });
     });
   });
 
@@ -207,15 +202,6 @@ describe("PerpetualTranche", function () {
       it("should revert", async function () {
         await expect(perp.connect(otherUser).updateVault(constants.AddressZero)).to.be.revertedWith(
           "Ownable: caller is not the owner",
-        );
-      });
-    });
-
-    describe("when reference is reset", function () {
-      it("should not revert", async function () {
-        await expect(perp.connect(deployer).updateVault(constants.AddressZero)).to.be.revertedWithCustomError(
-          perp,
-          "UnacceptableReference",
         );
       });
     });
@@ -233,9 +219,6 @@ describe("PerpetualTranche", function () {
       it("should update vault reference", async function () {
         expect(await perp.vault()).to.eq(vault.address);
       });
-      it("should emit event", async function () {
-        await expect(tx).to.emit(perp, "UpdatedVault").withArgs(vault.address);
-      });
     });
   });
 
@@ -250,15 +233,6 @@ describe("PerpetualTranche", function () {
       });
     });
 
-    describe("when set address is NOT valid", function () {
-      it("should revert", async function () {
-        await expect(perp.updateBondIssuer(constants.AddressZero)).to.be.revertedWithCustomError(
-          perp,
-          "UnacceptableReference",
-        );
-      });
-    });
-
     describe("when set address is valid", function () {
       beforeEach(async function () {
         const BondIssuer = await ethers.getContractFactory("BondIssuer");
@@ -269,9 +243,6 @@ describe("PerpetualTranche", function () {
       });
       it("should update reference", async function () {
         expect(await perp.bondIssuer()).to.eq(newIssuer.address);
-      });
-      it("should emit event", async function () {
-        await expect(tx).to.emit(perp, "UpdatedBondIssuer").withArgs(newIssuer.address);
       });
     });
 
@@ -298,15 +269,6 @@ describe("PerpetualTranche", function () {
       });
     });
 
-    describe("when set address is NOT valid", function () {
-      it("should revert", async function () {
-        await expect(perp.updateFeePolicy(constants.AddressZero)).to.be.revertedWithCustomError(
-          perp,
-          "UnacceptableReference",
-        );
-      });
-    });
-
     describe("when set strategy decimals dont match", function () {
       it("should revert", async function () {
         const FeePolicy = await ethers.getContractFactory("FeePolicy");
@@ -329,9 +291,6 @@ describe("PerpetualTranche", function () {
       });
       it("should update reference", async function () {
         expect(await perp.feePolicy()).to.eq(newFeePolicy.address);
-      });
-      it("should emit event", async function () {
-        await expect(tx).to.emit(perp, "UpdatedFeePolicy").withArgs(newFeePolicy.address);
       });
     });
   });
@@ -365,9 +324,6 @@ describe("PerpetualTranche", function () {
         expect(await perp.minTrancheMaturitySec()).to.eq(3600);
         expect(await perp.maxTrancheMaturitySec()).to.eq(86400);
       });
-      it("should emit event", async function () {
-        await expect(tx).to.emit(perp, "UpdatedTolerableTrancheMaturity").withArgs(3600, 86400);
-      });
     });
   });
 
@@ -390,9 +346,6 @@ describe("PerpetualTranche", function () {
       it("should update reference", async function () {
         expect(await perp.maxSupply()).to.eq(toFixedPtAmt("100"));
         expect(await perp.maxMintAmtPerTranche()).to.eq(toFixedPtAmt("20"));
-      });
-      it("should emit event", async function () {
-        await expect(tx).to.emit(perp, "UpdatedMintingLimits").withArgs(toFixedPtAmt("100"), toFixedPtAmt("20"));
       });
     });
   });
@@ -682,18 +635,6 @@ describe("PerpetualTranche", function () {
     });
 
     describe("when the deposit bond is not acceptable", function () {
-      describe("when deposit bond matures too soon", async function () {
-        beforeEach(async function () {
-          bond = await createBondWithFactory(bondFactory, collateralToken, [200, 800], 600);
-          await issuer.getLatestBond.returns(bond.address);
-          await perp.updateState();
-        });
-
-        it("should NOT update the deposit bond", async function () {
-          expect(await perp.callStatic.getDepositBond()).to.not.eq(bond.address);
-        });
-      });
-
       describe("when deposit bond matures too late", async function () {
         beforeEach(async function () {
           await perp.updateTolerableTrancheMaturity(1200, 7200);

--- a/spot-contracts/test/perp/PerpetualTranche_deposit.ts
+++ b/spot-contracts/test/perp/PerpetualTranche_deposit.ts
@@ -214,10 +214,7 @@ describe("PerpetualTranche", function () {
 
     describe("when tranche amount is zero", function () {
       it("should return without minting", async function () {
-        await expect(perp.deposit(depositTrancheA.address, "0")).to.revertedWithCustomError(
-          perp,
-          "UnacceptableDeposit",
-        );
+        expect(await perp.callStatic.deposit(depositTrancheA.address, "0")).to.eq("0");
       });
     });
 

--- a/spot-contracts/test/perp/PerpetualTranche_redeem.ts
+++ b/spot-contracts/test/perp/PerpetualTranche_redeem.ts
@@ -107,7 +107,7 @@ describe("PerpetualTranche", function () {
       });
 
       it("should revert", async function () {
-        await expect(perp.redeem(toFixedPtAmt("500"))).to.revertedWith("Pausable: paused");
+        await expect(perp.redeem(toFixedPtAmt("500"))).to.be.revertedWith("Pausable: paused");
       });
     });
 
@@ -118,13 +118,13 @@ describe("PerpetualTranche", function () {
 
       it("should revert", async function () {
         expect(await perp.balanceOf(deployerAddress)).to.lte(toFixedPtAmt("500"));
-        await expect(perp.redeem(toFixedPtAmt("500"))).to.revertedWithCustomError(perp, "UnacceptableRedemption");
+        await expect(perp.redeem(toFixedPtAmt("500"))).to.be.reverted;
       });
     });
 
     describe("when requested amount is zero", function () {
-      it("should revert", async function () {
-        await expect(perp.redeem("0")).to.revertedWithCustomError(perp, "UnacceptableRedemption");
+      it("should return without redeeming", async function () {
+        expect(await perp.callStatic.redeem("0")).to.deep.eq([]);
       });
     });
 
@@ -134,14 +134,11 @@ describe("PerpetualTranche", function () {
       });
 
       it("should revert", async function () {
-        await expect(perp.redeem(toFixedPtAmt("100"))).to.revertedWithCustomError(perp, "UnacceptableRedemption");
+        await expect(perp.redeem(toFixedPtAmt("100"))).to.be.reverted;
       });
 
-      it("should return revert", async function () {
-        await expect(perp.callStatic.computeRedemptionAmts(toFixedPtAmt("100"))).to.revertedWithCustomError(
-          perp,
-          "UnacceptableRedemption",
-        );
+      it("should revert", async function () {
+        await expect(perp.callStatic.computeRedemptionAmts(toFixedPtAmt("100"))).to.be.reverted;
       });
     });
 

--- a/spot-contracts/test/perp/PerpetualTranche_rollover.ts
+++ b/spot-contracts/test/perp/PerpetualTranche_rollover.ts
@@ -1,6 +1,6 @@
 import { expect, use } from "chai";
 import { network, ethers, upgrades } from "hardhat";
-import { Contract, Transaction, Signer, constants } from "ethers";
+import { Contract, Transaction, Signer } from "ethers";
 import { smock } from "@defi-wonderland/smock";
 import {
   setupCollateralToken,
@@ -285,7 +285,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           collateralToken.address,
           toFixedPtAmt("500"),
-          constants.MaxUint256,
         );
         expect(r.tokenOutAmt).to.eq(toFixedPtAmt("250"));
         expect(r.trancheInAmt).to.eq(toFixedPtAmt("500"));
@@ -308,7 +307,6 @@ describe("PerpetualTranche", function () {
           newRotationInTranche.address,
           newReserveTranche.address,
           toFixedPtAmt("500"),
-          constants.MaxUint256,
         );
         expect(r.tokenOutAmt).to.eq(toFixedPtAmt("500"));
         expect(r.trancheInAmt).to.eq(toFixedPtAmt("250"));
@@ -325,7 +323,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           collateralToken.address,
           toFixedPtAmt("500"),
-          constants.MaxUint256,
         );
         expect(r.tokenOutAmt).to.eq(toFixedPtAmt("500"));
         expect(r.trancheInAmt).to.eq(toFixedPtAmt("500"));
@@ -342,7 +339,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           collateralToken.address,
           toFixedPtAmt("500"),
-          constants.MaxUint256,
         );
         expect(r.tokenOutAmt).to.eq(toFixedPtAmt("250"));
         expect(r.trancheInAmt).to.eq(toFixedPtAmt("250"));
@@ -366,7 +362,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche2.address,
           collateralToken.address,
           toFixedPtAmt("500"),
-          constants.MaxUint256,
         );
         expect(r.tokenOutAmt).to.eq(toFixedPtAmt("250"));
         expect(r.trancheInAmt).to.eq(toFixedPtAmt("500"));
@@ -389,36 +384,9 @@ describe("PerpetualTranche", function () {
           rolloverInTranche2.address,
           collateralToken.address,
           toFixedPtAmt("500"),
-          constants.MaxUint256,
         );
         expect(r.tokenOutAmt).to.eq(toFixedPtAmt("250"));
         expect(r.trancheInAmt).to.eq(toFixedPtAmt("500"));
-      });
-    });
-
-    describe("when tokenOut is tranche and not covered", function () {
-      it("should rollover the correct amount", async function () {
-        const r = await perp.callStatic.computeRolloverAmt(
-          rolloverInTranche.address,
-          reserveTranche.address,
-          toFixedPtAmt("500"),
-          toFixedPtAmt("250"),
-        );
-        expect(r.tokenOutAmt).to.eq(toFixedPtAmt("250"));
-        expect(r.trancheInAmt).to.eq(toFixedPtAmt("250"));
-      });
-    });
-
-    describe("when tokenOut is collateral and not covered", function () {
-      it("should rollover the correct amount", async function () {
-        const r = await perp.callStatic.computeRolloverAmt(
-          rolloverInTranche.address,
-          collateralToken.address,
-          toFixedPtAmt("500"),
-          toFixedPtAmt("250"),
-        );
-        expect(r.tokenOutAmt).to.eq(toFixedPtAmt("250"));
-        expect(r.trancheInAmt).to.eq(toFixedPtAmt("250"));
       });
     });
 
@@ -431,7 +399,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           collateralToken.address,
           toFixedPtAmt("500"),
-          constants.MaxUint256,
         );
         expect(r.tokenOutAmt).to.eq(toFixedPtAmt("375"));
         expect(r.trancheInAmt).to.eq(toFixedPtAmt("375"));
@@ -447,52 +414,9 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           collateralToken.address,
           toFixedPtAmt("500"),
-          constants.MaxUint256,
         );
         expect(r.tokenOutAmt).to.eq(toFixedPtAmt("500"));
         expect(r.trancheInAmt).to.eq(toFixedPtAmt("500"));
-      });
-    });
-
-    describe("when trancheIn price is 0.5 and tokenOut is collateral has rebased down and NOT covered", function () {
-      let newRotationInTranche: Contract;
-      beforeEach(async function () {
-        const tranches = await getTranches(rolloverInBond);
-        newRotationInTranche = tranches[1];
-        await rebase(collateralToken, rebaseOracle, -0.75);
-      });
-      it("should rollover the correct amount", async function () {
-        const r = await perp.callStatic.computeRolloverAmt(
-          newRotationInTranche.address,
-          collateralToken.address,
-          toFixedPtAmt("500"),
-          toFixedPtAmt("93.75"),
-        );
-        expect(r.tokenOutAmt).to.eq(toFixedPtAmt("93.75"));
-        expect(r.trancheInAmt).to.eq(toFixedPtAmt("187.5"));
-      });
-    });
-
-    describe("when trancheIn price is 0.5 and tokenOut is collateral has rebased up and NOT covered", function () {
-      let newRotationInTranche: Contract;
-      beforeEach(async function () {
-        const tranches = await getTranches(rolloverInBond);
-        newRotationInTranche = tranches[1];
-        await rebase(collateralToken, rebaseOracle, -0.75);
-
-        // simulating collateral rebase up, by just transferring some tokens in
-        await mintCollteralToken(collateralToken, toFixedPtAmt("100"), deployer);
-        await collateralToken.transfer(perp.address, toFixedPtAmt("100"));
-      });
-      it("should rollover the correct amount", async function () {
-        const r = await perp.callStatic.computeRolloverAmt(
-          newRotationInTranche.address,
-          collateralToken.address,
-          toFixedPtAmt("500"),
-          toFixedPtAmt("156.25"),
-        );
-        expect(r.tokenOutAmt).to.eq(toFixedPtAmt("156.25"));
-        expect(r.trancheInAmt).to.eq(toFixedPtAmt("312.5"));
       });
     });
 
@@ -520,7 +444,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           reserveTranche.address,
           toFixedPtAmt("500"),
-          constants.MaxUint256,
         );
         expect(r.tokenOutAmt).to.eq(toFixedPtAmt("500"));
         expect(r.trancheInAmt).to.eq(toFixedPtAmt("500"));
@@ -546,7 +469,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           reserveTranche.address,
           toFixedPtAmt("500"),
-          constants.MaxUint256,
         );
         expect(r.tokenOutAmt).to.eq(toFixedPtAmt("495"));
         expect(r.trancheInAmt).to.eq(toFixedPtAmt("500"));
@@ -576,7 +498,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           reserveTranche.address,
           toFixedPtAmt("500"),
-          constants.MaxUint256,
         );
         expect(r.tokenOutAmt).to.eq(toFixedPtAmt("500"));
         expect(r.trancheInAmt).to.eq(toFixedPtAmt("495.049504950495049505"));
@@ -595,7 +516,6 @@ describe("PerpetualTranche", function () {
           newRotationInTranche.address,
           collateralToken.address,
           toFixedPtAmt("250"),
-          constants.MaxUint256,
         );
         tx = mockVault.rollover(
           perp.address,
@@ -632,7 +552,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           reserveTranche.address,
           toFixedPtAmt("250"),
-          constants.MaxUint256,
         );
         tx = mockVault.rollover(perp.address, rolloverInTranche.address, reserveTranche.address, toFixedPtAmt("250"));
         await tx;
@@ -665,7 +584,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           collateralToken.address,
           toFixedPtAmt("250"),
-          constants.MaxUint256,
         );
         tx = mockVault.rollover(perp.address, rolloverInTranche.address, collateralToken.address, toFixedPtAmt("250"));
         await tx;
@@ -699,7 +617,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           collateralToken.address,
           toFixedPtAmt("250"),
-          constants.MaxUint256,
         );
         tx = mockVault.rollover(perp.address, rolloverInTranche.address, collateralToken.address, toFixedPtAmt("250"));
         await tx;
@@ -733,7 +650,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           collateralToken.address,
           toFixedPtAmt("250"),
-          constants.MaxUint256,
         );
         tx = mockVault.rollover(perp.address, rolloverInTranche.address, collateralToken.address, toFixedPtAmt("250"));
         await tx;
@@ -766,7 +682,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           reserveTranche.address,
           toFixedPtAmt("500"),
-          constants.MaxUint256,
         );
         tx = mockVault.rollover(perp.address, rolloverInTranche.address, reserveTranche.address, toFixedPtAmt("500"));
         await tx;
@@ -800,7 +715,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           collateralToken.address,
           toFixedPtAmt("500"),
-          constants.MaxUint256,
         );
         tx = mockVault.rollover(perp.address, rolloverInTranche.address, collateralToken.address, toFixedPtAmt("500"));
         await tx;
@@ -833,7 +747,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           reserveTranche.address,
           toFixedPtAmt("100"),
-          constants.MaxUint256,
         );
         tx = mockVault.rollover(perp.address, rolloverInTranche.address, reserveTranche.address, toFixedPtAmt("100"));
         await tx;
@@ -867,7 +780,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           reserveTranche.address,
           toFixedPtAmt("2000"),
-          constants.MaxUint256,
         );
         tx = mockVault.rollover(perp.address, rolloverInTranche.address, reserveTranche.address, toFixedPtAmt("2000"));
         await tx;
@@ -902,7 +814,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           reserveTranche.address,
           toFixedPtAmt("2000"),
-          constants.MaxUint256,
         );
         tx = mockVault.rollover(perp.address, rolloverInTranche.address, reserveTranche.address, toFixedPtAmt("2000"));
         await tx;
@@ -937,7 +848,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           reserveTranche.address,
           toFixedPtAmt("2000"),
-          constants.MaxUint256,
         );
         tx = mockVault.rollover(perp.address, rolloverInTranche.address, reserveTranche.address, toFixedPtAmt("2000"));
         await tx;
@@ -971,7 +881,6 @@ describe("PerpetualTranche", function () {
           rolloverInTranche.address,
           collateralToken.address,
           toFixedPtAmt("100"),
-          constants.MaxUint256,
         );
         tx = mockVault.rollover(perp.address, rolloverInTranche.address, collateralToken.address, toFixedPtAmt("100"));
         await tx;

--- a/spot-contracts/test/rollover-vault/RolloverVault_deploy.ts
+++ b/spot-contracts/test/rollover-vault/RolloverVault_deploy.ts
@@ -409,9 +409,6 @@ describe("RolloverVault", function () {
         await expect(tx).to.emit(vault, "AssetSynced").withArgs(rolloverInTranches[1].address, toFixedPtAmt("792"));
 
         // Rollover
-        await expect(tx)
-          .to.emit(vault, "AssetSynced")
-          .withArgs(rolloverInTranches[0].address, toFixedPtAmt("79.188118811881188118"));
         await expect(tx).to.emit(vault, "AssetSynced").withArgs(reserveTranches[1].address, toFixedPtAmt("200"));
 
         // Recover

--- a/spot-contracts/test/rollover-vault/RolloverVault_deploy.ts
+++ b/spot-contracts/test/rollover-vault/RolloverVault_deploy.ts
@@ -94,7 +94,7 @@ describe("RolloverVault", function () {
     await collateralToken.approve(vault.address, toFixedPtAmt("1"));
 
     await checkVaultAssetComposition(vault, [collateralToken], ["0"]);
-    expect(await vault.deployedCount()).to.eq(0);
+    expect(await vault.assetCount()).to.eq(1);
   });
 
   afterEach(async function () {
@@ -104,7 +104,7 @@ describe("RolloverVault", function () {
   describe("#deploy", function () {
     describe("when usable balance is zero", function () {
       it("should revert", async function () {
-        await expect(vault.deploy()).to.be.revertedWithCustomError(vault, "InsufficientDeployment");
+        await expect(vault.deploy()).to.be.revertedWithCustomError(vault, "InsufficientLiquidity");
       });
     });
 
@@ -145,7 +145,7 @@ describe("RolloverVault", function () {
           await vault.updateMinDeploymentAmt(toFixedPtAmt("1"));
         });
         it("should revert", async function () {
-          await expect(vault.deploy()).to.be.revertedWithCustomError(vault, "InsufficientDeployment");
+          await expect(vault.deploy()).to.be.revertedWithCustomError(vault, "InsufficientLiquidity");
         });
       });
 
@@ -240,8 +240,8 @@ describe("RolloverVault", function () {
           await expect(vault.deploy()).not.to.be.reverted;
           await checkVaultAssetComposition(
             vault,
-            [collateralToken, newTranchesIn[0], newTranchesIn[1], curTranchesIn[0], curTranchesIn[1]],
-            [toFixedPtAmt("2600"), "0", toFixedPtAmt("3200"), toFixedPtAmt("800"), toFixedPtAmt("3200")],
+            [collateralToken, newTranchesIn[1], reserveTranches[3]],
+            [toFixedPtAmt("6600"), toFixedPtAmt("3200"), toFixedPtAmt("200")],
           );
           await checkReserveComposition(perp, [collateralToken, newTranchesIn[0]], ["0", toFixedPtAmt("800")]);
         });
@@ -255,14 +255,8 @@ describe("RolloverVault", function () {
           await expect(vault.deploy()).not.to.be.reverted;
           await checkVaultAssetComposition(
             vault,
-            [collateralToken, reserveTranches[3], newTranchesIn[1], curTranchesIn[0], curTranchesIn[1]],
-            [
-              toFixedPtAmt("11100"),
-              toFixedPtAmt("200"),
-              toFixedPtAmt("3200"),
-              toFixedPtAmt("800"),
-              toFixedPtAmt("3200"),
-            ],
+            [collateralToken, reserveTranches[3], newTranchesIn[1]],
+            [toFixedPtAmt("15100"), toFixedPtAmt("200"), toFixedPtAmt("3200")],
           );
           await checkReserveComposition(perp, [collateralToken, newTranchesIn[0]], ["0", toFixedPtAmt("800")]);
         });
@@ -413,14 +407,12 @@ describe("RolloverVault", function () {
         // Tranche
         await expect(tx).to.emit(vault, "AssetSynced").withArgs(rolloverInTranches[0].address, toFixedPtAmt("198"));
         await expect(tx).to.emit(vault, "AssetSynced").withArgs(rolloverInTranches[1].address, toFixedPtAmt("792"));
-        await expect(tx).to.emit(vault, "AssetSynced").withArgs(collateralToken.address, "0");
 
         // Rollover
         await expect(tx)
           .to.emit(vault, "AssetSynced")
           .withArgs(rolloverInTranches[0].address, toFixedPtAmt("79.188118811881188118"));
         await expect(tx).to.emit(vault, "AssetSynced").withArgs(reserveTranches[1].address, toFixedPtAmt("200"));
-        await expect(tx).to.emit(vault, "AssetSynced").withArgs(collateralToken.address, toFixedPtAmt("20"));
 
         // Recover
         await expect(tx)
@@ -429,6 +421,11 @@ describe("RolloverVault", function () {
         await expect(tx)
           .to.emit(vault, "AssetSynced")
           .withArgs(rolloverInTranches[1].address, toFixedPtAmt("475.247524752475248"));
+
+        // Final
+        await expect(tx)
+          .to.emit(vault, "AssetSynced")
+          .withArgs(collateralToken.address, toFixedPtAmt("415.94059405940594"));
       });
 
       it("should update the list of deployed assets", async function () {
@@ -469,7 +466,7 @@ describe("RolloverVault", function () {
     });
 
     it("should revert after limit is reached", async function () {
-      expect(await vault.deployedCount()).to.eq(46);
+      expect(await vault.assetCount()).to.eq(47);
       await setupDeployment();
       await expect(vault.deploy()).to.be.revertedWithCustomError(vault, "DeployedCountOverLimit");
     });


### PR DESCRIPTION
Contains changes from comments in [this](https://docs.google.com/spreadsheets/d/1kDIujHNLutL0bXB4bjeFQK9n8RNehZs2lrNqilSzUus/edit#gid=0) sheet (colored in orange). 

Additionally
* Added max reserve length parameter to perp (similar to the vault)
* Updated perp's `getReserveTokensUpForRollover` method to remove `address(0)` and return a smaller array with just the tokens to rollover. It consumes slightly more gas, but lesser data is passed downstream. 
* Enforcing vault's liquidity constraints on both swap functions. (its a cheap check and there could be weird cases where the swapPerpsForUnderlying fn decreases the available vault liquidity when it does not have the matching juniors) 
* Fixed bug in the router contract, which first has to issue the deposit bond before querying it.
