### PR TITLE
Charm Vault manager update

### DIFF
--- a/spot-vaults/README.md
+++ b/spot-vaults/README.md
@@ -6,6 +6,7 @@ The official mainnet addresses are:
 
 - Bill Broker (SPOT-USDC): [0xA088Aef966CAD7fE0B38e28c2E07590127Ab4ccB](https://etherscan.io/address/0xA088Aef966CAD7fE0B38e28c2E07590127Ab4ccB)
 - SpotAppraiser: [0x965FBFebDA76d9AA11642C1d0074CdF02e546F3c](https://etherscan.io/address/0x965FBFebDA76d9AA11642C1d0074CdF02e546F3c)
+- WethWamplManager: [0x6785fa26191eb531c54fd093931f395c4b01b583](https://etherscan.io/address/0x6785fa26191eb531c54fd093931f395c4b01b583)
 
 The official testnet addresses are:
 

--- a/spot-vaults/contracts/UsdcSpotManager.sol
+++ b/spot-vaults/contracts/UsdcSpotManager.sol
@@ -125,7 +125,7 @@ contract UsdcSpotManager {
 
     /// @notice Executes vault rebalance.
     function rebalance() public {
-        (uint256 deviation, bool deviaitonValid) = computeDeviationFactor();
+        (uint256 deviation, bool deviationValid) = computeDeviationFactor();
 
         // We rebalance if the deviation factor has crossed ONE (in either direction).
         bool forceLiquidityUpdate = ((deviation <= ONE && prevDeviation > ONE) ||
@@ -141,7 +141,7 @@ contract UsdcSpotManager {
         // the vault sells SPOT and deviation is above ONE, or when
         // the vault buys SPOT and deviation is below ONE
         bool extraSpot = isOverweightSpot();
-        bool activeLimitRange = deviaitonValid &&
+        bool activeLimitRange = deviationValid &&
             ((deviation >= ONE && extraSpot) || (deviation <= ONE && !extraSpot));
 
         // Trim positions after rebalance.
@@ -159,12 +159,12 @@ contract UsdcSpotManager {
         uint256 spotMarketPrice = getSpotUSDPrice();
         (uint256 spotTargetPrice, bool spotTargetPriceValid) = spotAppraiser.perpPrice();
         (, bool usdcPriceValid) = spotAppraiser.usdPrice();
-        bool deviaitonValid = (spotTargetPriceValid && usdcPriceValid);
+        bool deviationValid = (spotTargetPriceValid && usdcPriceValid);
         uint256 deviation = spotTargetPrice > 0
             ? FullMath.mulDiv(spotMarketPrice, ONE, spotTargetPrice)
             : type(uint256).max;
         deviation = (deviation > MAX_DEVIATION) ? MAX_DEVIATION : deviation;
-        return (deviation, deviaitonValid);
+        return (deviation, deviationValid);
     }
 
     //-----------------------------------------------------------------------------

--- a/spot-vaults/contracts/UsdcSpotManager.sol
+++ b/spot-vaults/contracts/UsdcSpotManager.sol
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: BUSL-1.1
+// solhint-disable-next-line compiler-version
+pragma solidity ^0.7.6;
+pragma abicoder v2;
+
+import { FullMath } from "@uniswap/v3-core/contracts/libraries/FullMath.sol";
+import { TickMath } from "@uniswap/v3-core/contracts/libraries/TickMath.sol";
+import { PositionKey } from "@uniswap/v3-periphery/contracts/libraries/PositionKey.sol";
+
+import { IBillBrokerPricingStrategy } from "./_interfaces/IBillBrokerPricingStrategy.sol";
+import { IAlphaProVault } from "./_interfaces/external/IAlphaProVault.sol";
+import { IUniswapV3Pool } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
+
+/// @title UsdcSpotManager
+/// @notice This contract is a programmatic manager for the USDC-SPOT Charm AlphaProVault.
+contract UsdcSpotManager {
+    /// @dev Token Constants.
+    uint256 public constant ONE_SPOT = 1e9;
+    uint256 public constant ONE_USDC = 1e6;
+
+    /// @dev Decimals.
+    uint256 public constant DECIMALS = 18;
+    uint256 public constant ONE = (10 ** DECIMALS);
+
+    /// @dev We bound the deviation factor to 100.0.
+    uint256 public constant MAX_DEVIATION = 100 * ONE; // 100.0
+
+    //-------------------------------------------------------------------------
+    // Storage
+
+    /// @notice The USDC-SPOT charm alpha vault.
+    IAlphaProVault public immutable VAULT;
+
+    /// @notice The underlying USDC-SPOT univ3 pool.
+    IUniswapV3Pool public immutable POOL;
+
+    /// @notice The vault's token0, the USDC token.
+    address public immutable USDC;
+
+    /// @notice The vault's token1, the SPOT token.
+    address public immutable SPOT;
+
+    /// @notice Pricing strategy to price the SPOT token.
+    IBillBrokerPricingStrategy public spotAppraiser;
+
+    /// @notice The contract owner.
+    address public owner;
+
+    //-------------------------------------------------------------------------
+    // Manager storage
+
+    /// @notice The recorded deviation factor at the time of the last successful rebalance operation.
+    uint256 public prevDeviation;
+
+    //--------------------------------------------------------------------------
+    // Modifiers
+
+    modifier onlyOwner() {
+        // solhint-disable-next-line custom-errors
+        require(msg.sender == owner, "Unauthorized caller");
+        _;
+    }
+
+    //-----------------------------------------------------------------------------
+    // Constructor and Initializer
+
+    /// @notice Constructor initializes the contract with provided addresses.
+    /// @param vault_ Address of the AlphaProVault contract.
+    /// @param spotAppraiser_ Address of the spot appraiser.
+    constructor(IAlphaProVault vault_, IBillBrokerPricingStrategy spotAppraiser_) {
+        owner = msg.sender;
+
+        VAULT = vault_;
+        POOL = vault_.pool();
+        USDC = vault_.token0();
+        SPOT = vault_.token1();
+
+        spotAppraiser = spotAppraiser_;
+        // solhint-disable-next-line custom-errors
+        require(spotAppraiser.decimals() == DECIMALS, "Invalid decimals");
+    }
+
+    //--------------------------------------------------------------------------
+    // Owner only methods
+
+    /// @notice Updates the owner role.
+    function transferOwnership(address owner_) external onlyOwner {
+        owner = owner_;
+    }
+
+    /// @notice Updates the Spot Appraiser reference.
+    function setSpotAppraiser(
+        IBillBrokerPricingStrategy spotAppraiser_
+    ) external onlyOwner {
+        spotAppraiser = spotAppraiser_;
+    }
+
+    /// @notice Updates the vault's liquidity range parameters.
+    function setLiquidityRanges(
+        int24 baseThreshold,
+        uint24 fullRangeWeight,
+        int24 limitThreshold
+    ) external onlyOwner {
+        // Update liquidity parameters on the vault.
+        VAULT.setBaseThreshold(baseThreshold);
+        VAULT.setFullRangeWeight(fullRangeWeight);
+        VAULT.setLimitThreshold(limitThreshold);
+    }
+
+    /// @notice Forwards the given calldata to the vault.
+    /// @param callData The calldata to pass to the vault.
+    /// @return The data returned by the vault method call.
+    function execOnVault(
+        bytes calldata callData
+    ) external onlyOwner returns (bytes memory) {
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory r) = address(VAULT).call(callData);
+        // solhint-disable-next-line custom-errors
+        require(success, "Vault call failed");
+        return r;
+    }
+
+    //--------------------------------------------------------------------------
+    // External write methods
+
+    /// @notice Executes vault rebalance.
+    function rebalance() public {
+        (uint256 deviation, bool deviaitonValid) = computeDeviationFactor();
+
+        // We rebalance if the deviation factor has crossed ONE (in either direction).
+        bool forceLiquidityUpdate = ((deviation <= ONE && prevDeviation > ONE) ||
+            (deviation >= ONE && prevDeviation < ONE));
+
+        // Execute rebalance.
+        // NOTE: the vault.rebalance() will revert if enough time has not elapsed.
+        // We thus override with a force rebalance.
+        // https://learn.charm.fi/charm/technical-references/core/alphaprovault#rebalance
+        forceLiquidityUpdate ? _execForceRebalance() : VAULT.rebalance();
+
+        // We only activate the limit range liquidity, when
+        // the vault sells SPOT and deviation is above ONE, or when
+        // the vault buys SPOT and deviation is below ONE
+        bool extraSpot = isOverweightSpot();
+        bool activeLimitRange = deviaitonValid &&
+            ((deviation >= ONE && extraSpot) || (deviation <= ONE && !extraSpot));
+
+        // Trim positions after rebalance.
+        if (!activeLimitRange) {
+            _removeLimitLiquidity();
+        }
+
+        // Update rebalance state.
+        prevDeviation = deviation;
+    }
+
+    /// @notice Computes the deviation between SPOT's market price and it's FMV price.
+    /// @return The computed deviation factor.
+    function computeDeviationFactor() public returns (uint256, bool) {
+        uint256 spotMarketPrice = getSpotUSDPrice();
+        (uint256 spotTargetPrice, bool spotTargetPriceValid) = spotAppraiser.perpPrice();
+        (, bool usdcPriceValid) = spotAppraiser.usdPrice();
+        bool deviaitonValid = (spotTargetPriceValid && usdcPriceValid);
+        uint256 deviation = spotTargetPrice > 0
+            ? FullMath.mulDiv(spotMarketPrice, ONE, spotTargetPrice)
+            : type(uint256).max;
+        deviation = (deviation > MAX_DEVIATION) ? MAX_DEVIATION : deviation;
+        return (deviation, deviaitonValid);
+    }
+
+    //-----------------------------------------------------------------------------
+    // External Public view methods
+
+    /// @return The computed SPOT price in USD from the underlying univ3 pool.
+    function getSpotUSDPrice() public view returns (uint256) {
+        uint160 sqrtPriceX96 = TickMath.getSqrtRatioAtTick(VAULT.getTwap());
+        uint256 ratioX192 = uint256(sqrtPriceX96) * sqrtPriceX96;
+        uint256 spotPerUsdc = FullMath.mulDiv(ONE, ratioX192, (1 << 192));
+        return FullMath.mulDiv(spotPerUsdc, ONE_USDC, ONE_SPOT);
+    }
+
+    /// @notice Checks the vault is overweight SPOT, and looking to sell the extra SPOT for USDC.
+    function isOverweightSpot() public view returns (bool) {
+        // NOTE: This assumes that in the underlying univ3 pool and
+        // token0 is USDC and token1 is SPOT.
+        int24 _marketPrice = VAULT.getTwap();
+        int24 _limitLower = VAULT.limitLower();
+        int24 _limitUpper = VAULT.limitUpper();
+        int24 _limitPrice = (_limitLower + _limitUpper) / 2;
+        // The limit range has more token1 than token0 if `_marketPrice >= _limitPrice`,
+        // so the vault looks to sell token1.
+        return (_marketPrice >= _limitPrice);
+    }
+
+    /// @return Number of decimals representing 1.0.
+    function decimals() external pure returns (uint8) {
+        return uint8(DECIMALS);
+    }
+
+    //-----------------------------------------------------------------------------
+    // Private methods
+
+    /// @dev A low-level method, which interacts directly with the vault and executes
+    ///      a rebalance even when enough time hasn't elapsed since the last rebalance.
+    function _execForceRebalance() private {
+        uint32 _period = VAULT.period();
+        VAULT.setPeriod(0);
+        VAULT.rebalance();
+        VAULT.setPeriod(_period);
+    }
+
+    /// @dev Removes the vault's limit range liquidity.
+    ///      To be invoked right after a rebalance operation, as it assumes that
+    ///      the vault has a active limit range liquidity.
+    function _removeLimitLiquidity() private {
+        int24 _limitLower = VAULT.limitLower();
+        int24 _limitUpper = VAULT.limitUpper();
+        (uint128 limitLiquidity, , , , ) = _position(_limitLower, _limitUpper);
+        // docs: https://learn.charm.fi/charm/technical-references/core/alphaprovault#emergencyburn
+        VAULT.emergencyBurn(_limitLower, _limitUpper, limitLiquidity);
+    }
+
+    /// @dev Wrapper around `IUniswapV3Pool.positions()`.
+    function _position(
+        int24 tickLower,
+        int24 tickUpper
+    ) private view returns (uint128, uint256, uint256, uint128, uint128) {
+        bytes32 positionKey = PositionKey.compute(address(VAULT), tickLower, tickUpper);
+        return POOL.positions(positionKey);
+    }
+}

--- a/spot-vaults/contracts/WethWamplManager.sol
+++ b/spot-vaults/contracts/WethWamplManager.sol
@@ -216,10 +216,10 @@ contract WethWamplManager {
     /// @notice Executes vault rebalance.
     function rebalance() public {
         // Get the current deviation factor.
-        (uint256 deviation, bool deviaitonValid) = computeDeviationFactor();
+        (uint256 deviation, bool deviationValid) = computeDeviationFactor();
 
         // Calculate the current active liquidity percentage.
-        uint256 activeLiqPerc = deviaitonValid
+        uint256 activeLiqPerc = deviationValid
             ? computeActiveLiqPerc(deviation)
             : MIN_ACTIVE_LIQ_PERC;
 
@@ -244,7 +244,7 @@ contract WethWamplManager {
         // the vault sells WAMPL and deviation is above ONE, or when
         // the vault buys WAMPL and deviation is below ONE
         bool extraWampl = isOverweightWampl();
-        bool activeLimitRange = deviaitonValid &&
+        bool activeLimitRange = deviationValid &&
             ((deviation >= ONE && extraWampl) || (deviation <= ONE && !extraWampl));
 
         // Trim positions after rebalance.
@@ -262,12 +262,12 @@ contract WethWamplManager {
         (uint256 targetPrice, bool targetPriceValid) = _getAmpleforthOracleData(
             cpiOracle
         );
-        bool deviaitonValid = (ethPriceValid && targetPriceValid);
+        bool deviationValid = (ethPriceValid && targetPriceValid);
         uint256 deviation = (targetPrice > 0)
             ? FullMath.mulDiv(marketPrice, ONE, targetPrice)
             : type(uint256).max;
         deviation = (deviation > MAX_DEVIATION) ? MAX_DEVIATION : deviation;
-        return (deviation, deviaitonValid);
+        return (deviation, deviationValid);
     }
 
     //-----------------------------------------------------------------------------

--- a/spot-vaults/contracts/WethWamplManager.sol
+++ b/spot-vaults/contracts/WethWamplManager.sol
@@ -65,7 +65,7 @@ contract WethWamplManager {
     // AMPL's current market price and its target price.
     // The deviation is 1.0, when AMPL is at the target.
     //
-    // The active liquidity percentage (a value between 25% to 100%)
+    // The active liquidity percentage (a value between 20% to 100%)
     // is computed based on pair-wise linear function, defined by the contract owner.
     //
     // If the current deviation is below ONE, function f1 is used

--- a/spot-vaults/contracts/_interfaces/IBillBrokerPricingStrategy.sol
+++ b/spot-vaults/contracts/_interfaces/IBillBrokerPricingStrategy.sol
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.24;
 
 /**
  * @title IBillBrokerPricingStrategy
@@ -8,6 +7,7 @@ pragma solidity ^0.8.24;
  *         which accepts Perp and USDC tokens.
  *
  */
+// solhint-disable-next-line compiler-version
 interface IBillBrokerPricingStrategy {
     /// @return Number of decimals representing the prices returned.
     function decimals() external pure returns (uint8);

--- a/spot-vaults/package.json
+++ b/spot-vaults/package.json
@@ -62,7 +62,7 @@
     "ethers": "^6.6.0",
     "ethers-v5": "npm:ethers@^5.7.0",
     "ganache-cli": "latest",
-    "hardhat": "^2.22.1",
+    "hardhat": "^2.22.6",
     "hardhat-gas-reporter": "latest",
     "lodash": "^4.17.21",
     "prettier": "^2.7.1",

--- a/spot-vaults/tasks/deploy.ts
+++ b/spot-vaults/tasks/deploy.ts
@@ -117,7 +117,7 @@ task("deploy:WethWamplManager")
       await sleep(30);
       await hre.run("verify:contract", {
         address: manager.target,
-        constructorArguments: [vault, ethOracle, cpiOracle],
+        constructorArguments: [vault, cpiOracle, ethOracle],
       });
     } else {
       console.log("Skipping verification");

--- a/spot-vaults/tasks/info.ts
+++ b/spot-vaults/tasks/info.ts
@@ -151,21 +151,6 @@ task("info:WethWamplManager")
     console.log("ethOracle:", await manager.ethOracle());
 
     console.log("---------------------------------------------------------------");
-    const deviation = await manager.computeDeviationFactor.staticCall();
-    console.log("amplDeviation:", pp(deviation, managerDecimals));
-    console.log(
-      "inNarrowLimitRange:",
-      await manager.checkNarrowLimitRange.staticCall(deviation),
-    );
-    console.log(
-      "lastActiveLiqPerc:",
-      pp(await manager.lastActiveLiqPerc(), managerDecimals),
-    );
-    console.log(
-      "activeLiqPerc:",
-      pp(await manager.computeActiveLiqPerc(deviation), managerDecimals),
-    );
-
     const ethPriceData = await manager.getEthUSDPrice();
     console.log("ethPrice:", pp(ethPriceData[0], managerDecimals));
 
@@ -174,6 +159,17 @@ task("info:WethWamplManager")
 
     const amplPrice = await manager.getAmplUSDPrice(ethPriceData[0]);
     console.log("amplPrice:", pp(amplPrice, managerDecimals));
+
+    const r = await manager.computeDeviationFactor.staticCall();
+    const deviation = r[0];
+    console.log("dataValid:", r[1]);
+    console.log("isOverweightWampl:", await manager.isOverweightWampl());
+    console.log("prevDeviation:", pp(await manager.prevDeviation(), managerDecimals));
+    console.log("amplDeviation:", pp(deviation, managerDecimals));
+    console.log(
+      "activeLiqPerc:",
+      pp(await manager.computeActiveLiqPerc(deviation), managerDecimals),
+    );
 
     let rebalanceActive = true;
     try {

--- a/spot-vaults/test/UsdcSpotManager.ts
+++ b/spot-vaults/test/UsdcSpotManager.ts
@@ -1,0 +1,444 @@
+import { ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { expect } from "chai";
+import { DMock, sciParseFloat, univ3PositionKey } from "./helpers";
+
+export const percFP = (a: string): BigInt => ethers.parseUnits(sciParseFloat(a), 18);
+export const spotFP = (a: string): BigInt => ethers.parseUnits(sciParseFloat(a), 9);
+export const usdcFP = (a: string): BigInt => ethers.parseUnits(sciParseFloat(a), 6);
+export const priceFP = (a: string): BigInt => ethers.parseUnits(sciParseFloat(a), 18);
+
+describe("UsdcSpotManager", function () {
+  async function setupContracts() {
+    const accounts = await ethers.getSigners();
+    const owner = accounts[0];
+    const addr1 = accounts[1];
+
+    // Deploy mock contracts
+    const mockVault = new DMock("IAlphaProVault");
+    await mockVault.deploy();
+    await mockVault.mockMethod("fullLower()", [-800000]);
+    await mockVault.mockMethod("fullUpper()", [800000]);
+    await mockVault.mockMethod("baseLower()", [45000]);
+    await mockVault.mockMethod("baseUpper()", [55000]);
+    await mockVault.mockMethod("getTwap()", [71000]);
+    await mockVault.mockMethod("limitThreshold()", [800000]);
+
+    const mockPool = new DMock("IUniswapV3Pool");
+    await mockPool.deploy();
+    await mockVault.mockMethod("pool()", [mockPool.target]);
+
+    const mockAppraiser = new DMock("IBillBrokerPricingStrategy");
+    await mockAppraiser.deploy();
+    await mockAppraiser.mockMethod("decimals()", [18]);
+    await mockAppraiser.mockMethod("perpPrice()", [priceFP("1.2"), true]);
+    await mockAppraiser.mockMethod("usdPrice()", [priceFP("1"), true]);
+
+    const mockUsdc = new DMock("IERC20Upgradeable");
+    await mockUsdc.deploy();
+    await mockVault.mockMethod("token0()", [mockUsdc.target]);
+
+    const mockSpot = new DMock("IERC20Upgradeable");
+    await mockSpot.deploy();
+    await mockVault.mockMethod("token1()", [mockSpot.target]);
+
+    // Deploy Manager contract
+    const Manager = await ethers.getContractFactory("UsdcSpotManager");
+    const manager = await Manager.deploy(mockVault.target, mockAppraiser.target);
+
+    return {
+      owner,
+      addr1,
+      mockVault,
+      mockAppraiser,
+      mockUsdc,
+      mockSpot,
+      mockPool,
+      manager,
+    };
+  }
+
+  describe("Initialization", function () {
+    it("should set the correct owner", async function () {
+      const { manager, owner } = await loadFixture(setupContracts);
+      expect(await manager.owner()).to.eq(await owner.getAddress());
+    });
+
+    it("should set the correct vault address", async function () {
+      const { manager, mockVault } = await loadFixture(setupContracts);
+      expect(await manager.VAULT()).to.eq(mockVault.target);
+    });
+
+    it("should set the appraiser address", async function () {
+      const { manager, mockAppraiser } = await loadFixture(setupContracts);
+      expect(await manager.spotAppraiser()).to.eq(mockAppraiser.target);
+    });
+
+    it("should set the token refs", async function () {
+      const { manager, mockUsdc, mockSpot, mockPool } = await loadFixture(setupContracts);
+      expect(await manager.POOL()).to.eq(mockPool.target);
+      expect(await manager.USDC()).to.eq(mockUsdc.target);
+      expect(await manager.SPOT()).to.eq(mockSpot.target);
+    });
+
+    it("should return the decimals", async function () {
+      const { manager } = await loadFixture(setupContracts);
+      expect(await manager.decimals()).to.eq(18);
+    });
+  });
+
+  describe("#transferOwnership", function () {
+    it("should fail to when called by non-owner", async function () {
+      const { manager, addr1 } = await loadFixture(setupContracts);
+      await expect(
+        manager.connect(addr1).transferOwnership(addr1.address),
+      ).to.be.revertedWith("Unauthorized caller");
+    });
+
+    it("should succeed when called by owner", async function () {
+      const { manager, addr1 } = await loadFixture(setupContracts);
+      await manager.transferOwnership(addr1.address);
+      expect(await manager.owner()).to.eq(await addr1.getAddress());
+    });
+  });
+
+  describe("#setSpotAppraiser", function () {
+    it("should fail to when called by non-owner", async function () {
+      const { manager, addr1 } = await loadFixture(setupContracts);
+      await expect(
+        manager.connect(addr1).setSpotAppraiser(addr1.address),
+      ).to.be.revertedWith("Unauthorized caller");
+    });
+
+    it("should succeed when called by owner", async function () {
+      const { manager, addr1 } = await loadFixture(setupContracts);
+      await manager.setSpotAppraiser(addr1.address);
+      expect(await manager.spotAppraiser()).to.eq(await addr1.getAddress());
+    });
+  });
+
+  describe("#setLiquidityRanges", function () {
+    it("should fail to when called by non-owner", async function () {
+      const { manager, addr1 } = await loadFixture(setupContracts);
+      await expect(
+        manager.connect(addr1).setLiquidityRanges(7200, 330000, 1200),
+      ).to.be.revertedWith("Unauthorized caller");
+    });
+
+    it("should succeed when called by owner", async function () {
+      const { manager, mockVault } = await loadFixture(setupContracts);
+      await mockVault.mockCall("setBaseThreshold(int24)", [7200], []);
+      await mockVault.mockCall("setFullRangeWeight(uint24)", [330000], []);
+      await mockVault.mockCall("setLimitThreshold(int24)", [1200], []);
+      await manager.setLiquidityRanges(7200, 330000, 1200);
+    });
+  });
+
+  describe("#execOnVault", function () {
+    it("should fail to when called by non-owner", async function () {
+      const { manager, addr1, mockVault } = await loadFixture(setupContracts);
+      await expect(
+        manager
+          .connect(addr1)
+          .execOnVault(
+            mockVault.refFactory.interface.encodeFunctionData("acceptManager"),
+          ),
+      ).to.be.revertedWith("Unauthorized caller");
+    });
+
+    it("should succeed when called by owner", async function () {
+      const { manager, mockVault } = await loadFixture(setupContracts);
+      await mockVault.mockCall("setManager(address)", [ethers.ZeroAddress], []);
+      await manager.execOnVault(
+        mockVault.refFactory.interface.encodeFunctionData("setManager", [
+          ethers.ZeroAddress,
+        ]),
+      );
+    });
+
+    it("should revert if call failed", async function () {
+      const { manager, mockVault } = await loadFixture(setupContracts);
+      await expect(
+        manager.execOnVault(
+          mockVault.refFactory.interface.encodeFunctionData("acceptManager"),
+        ),
+      ).to.be.revertedWith("Vault call failed");
+      await mockVault.mockCall("acceptManager()", [], []);
+      await manager.execOnVault(
+        mockVault.refFactory.interface.encodeFunctionData("acceptManager"),
+      );
+    });
+  });
+
+  describe("#computeDeviationFactor", function () {
+    describe("when spot price is invalid", function () {
+      it("should return invalid", async function () {
+        const { manager, mockAppraiser } = await loadFixture(setupContracts);
+        await mockAppraiser.mockMethod("perpPrice()", [priceFP("1.2"), false]);
+        const r = await manager.computeDeviationFactor.staticCall();
+        expect(r[0]).to.eq(percFP("1.009614109343384160"));
+        expect(r[1]).to.eq(false);
+      });
+    });
+
+    describe("when usd price is invalid", function () {
+      it("should return invalid", async function () {
+        const { manager, mockAppraiser } = await loadFixture(setupContracts);
+        await mockAppraiser.mockMethod("usdPrice()", [priceFP("0.8"), false]);
+        const r = await manager.computeDeviationFactor.staticCall();
+        expect(r[0]).to.eq(percFP("1.009614109343384160"));
+        expect(r[1]).to.eq(false);
+      });
+    });
+
+    it("should return deviation factor", async function () {
+      const { manager } = await loadFixture(setupContracts);
+      const r = await manager.computeDeviationFactor.staticCall();
+      expect(r[0]).to.eq(percFP("1.009614109343384160"));
+      expect(r[1]).to.eq(true);
+    });
+
+    it("should return deviation factor", async function () {
+      const { manager, mockVault } = await loadFixture(setupContracts);
+      await mockVault.mockMethod("getTwap()", [72500]);
+      const r = await manager.computeDeviationFactor.staticCall();
+      expect(r[0]).to.eq(percFP("1.172995447264373845"));
+      expect(r[1]).to.eq(true);
+    });
+
+    it("should return deviation factor", async function () {
+      const { manager, mockVault } = await loadFixture(setupContracts);
+      await mockVault.mockMethod("getTwap()", [70500]);
+      const r = await manager.computeDeviationFactor.staticCall();
+      expect(r[0]).to.eq(percFP("0.960377048978079093"));
+      expect(r[1]).to.eq(true);
+    });
+
+    it("should return deviation factor", async function () {
+      const { manager, mockAppraiser } = await loadFixture(setupContracts);
+      await mockAppraiser.mockMethod("perpPrice()", [priceFP("1.5"), true]);
+      const r = await manager.computeDeviationFactor.staticCall();
+      expect(r[0]).to.eq(percFP("0.807691287474707328"));
+      expect(r[1]).to.eq(true);
+    });
+
+    it("should return deviation factor", async function () {
+      const { manager, mockAppraiser } = await loadFixture(setupContracts);
+      await mockAppraiser.mockMethod("perpPrice()", [priceFP("1"), true]);
+      const r = await manager.computeDeviationFactor.staticCall();
+      expect(r[0]).to.eq(percFP("1.211536931212060992"));
+      expect(r[1]).to.eq(true);
+    });
+
+    it("should return deviation factor when perp price is invalid", async function () {
+      const { manager, mockAppraiser } = await loadFixture(setupContracts);
+      await mockAppraiser.mockMethod("perpPrice()", [priceFP("0"), true]);
+      const r = await manager.computeDeviationFactor.staticCall();
+      expect(r[0]).to.eq(percFP("100"));
+      expect(r[1]).to.eq(true);
+    });
+  });
+
+  describe("isOverweightSpot", function () {
+    describe("when spot sell", function () {
+      it("should return true", async function () {
+        const { manager, mockVault } = await loadFixture(setupContracts);
+        await mockVault.mockMethod("getTwap()", [30001]);
+        await mockVault.mockMethod("limitLower()", [20000]);
+        await mockVault.mockMethod("limitUpper()", [40000]);
+        expect(await manager.isOverweightSpot()).to.eq(true);
+      });
+    });
+
+    describe("when spot buy", function () {
+      it("should return false", async function () {
+        const { manager, mockVault } = await loadFixture(setupContracts);
+        await mockVault.mockMethod("getTwap()", [29999]);
+        await mockVault.mockMethod("limitLower()", [20000]);
+        await mockVault.mockMethod("limitUpper()", [40000]);
+        expect(await manager.isOverweightSpot()).to.eq(false);
+      });
+    });
+  });
+
+  describe("#rebalance", function () {
+    describe("when deviation is < 1 and goes > 1", function () {
+      describe("when overweight spot", function () {
+        it("should keep limit range", async function () {
+          const { manager, mockVault } = await loadFixture(setupContracts);
+
+          await mockVault.mockMethod("getTwap()", [72000]);
+          await mockVault.mockMethod("limitLower()", [40000]);
+          await mockVault.mockMethod("limitUpper()", [45000]);
+
+          await mockVault.mockMethod("period()", [86400]);
+          await mockVault.mockCall("setPeriod(uint32)", [0], []);
+          await mockVault.mockCall("setPeriod(uint32)", [86400], []);
+          await mockVault.mockMethod("rebalance()", []);
+
+          expect(await manager.prevDeviation()).to.eq("0");
+          expect(await manager.isOverweightSpot()).to.eq(true);
+          await expect(manager.rebalance()).not.to.be.reverted;
+          expect(await manager.prevDeviation()).to.eq(percFP("1.11579057353024426"));
+        });
+      });
+
+      describe("when overweight usdc", function () {
+        it("should remove limit range", async function () {
+          const { manager, mockVault, mockPool } = await loadFixture(setupContracts);
+
+          await mockVault.mockMethod("getTwap()", [72000]);
+          await mockVault.mockMethod("limitLower()", [73000]);
+          await mockVault.mockMethod("limitUpper()", [75000]);
+          await mockPool.mockCall(
+            "positions(bytes32)",
+            [univ3PositionKey(mockVault.target, 73000, 75000)],
+            [50000, 0, 0, 0, 0],
+          );
+
+          await mockVault.mockMethod("period()", [86400]);
+          await mockVault.mockCall("setPeriod(uint32)", [0], []);
+          await mockVault.mockCall("setPeriod(uint32)", [86400], []);
+          await mockVault.mockMethod("rebalance()", []);
+          await mockVault.mockCall(
+            "emergencyBurn(int24,int24,uint128)",
+            [73000, 75000, 50000],
+            [],
+          );
+
+          expect(await manager.prevDeviation()).to.eq("0");
+          expect(await manager.isOverweightSpot()).to.eq(false);
+          await expect(manager.rebalance()).not.to.be.reverted;
+          expect(await manager.prevDeviation()).to.eq(percFP("1.115790573530244260"));
+        });
+      });
+    });
+
+    describe("when deviation is > 1 and goes < 1", function () {
+      describe("when overweight spot", function () {
+        it("should remove limit range", async function () {
+          const { manager, mockVault, mockPool } = await loadFixture(setupContracts);
+
+          await mockVault.mockMethod("getTwap()", [72000]);
+          await mockVault.mockMethod("limitLower()", [40000]);
+          await mockVault.mockMethod("limitUpper()", [45000]);
+          await mockVault.mockMethod("period()", [86400]);
+          await mockVault.mockCall("setPeriod(uint32)", [0], []);
+          await mockVault.mockCall("setPeriod(uint32)", [86400], []);
+          await mockVault.mockMethod("rebalance()", []);
+          await manager.rebalance();
+
+          await mockVault.mockMethod("getTwap()", [70000]);
+          await mockVault.mockMethod("limitLower()", [60000]);
+          await mockVault.mockMethod("limitUpper()", [65000]);
+          await mockPool.mockCall(
+            "positions(bytes32)",
+            [univ3PositionKey(mockVault.target, 60000, 65000)],
+            [50000, 0, 0, 0, 0],
+          );
+          await mockVault.clearMockMethod("emergencyBurn(int24,int24,uint128)");
+          await mockVault.mockCall(
+            "emergencyBurn(int24,int24,uint128)",
+            [60000, 65000, 50000],
+            [],
+          );
+
+          expect(await manager.prevDeviation()).to.eq(percFP("1.115790573530244260"));
+          expect(await manager.isOverweightSpot()).to.eq(true);
+          await expect(manager.rebalance()).not.to.be.reverted;
+          expect(await manager.prevDeviation()).to.eq(percFP("0.913541191300990579"));
+        });
+      });
+
+      describe("when overweight usdc", function () {
+        it("should keep limit range", async function () {
+          const { manager, mockVault } = await loadFixture(setupContracts);
+
+          await mockVault.mockMethod("getTwap()", [72000]);
+          await mockVault.mockMethod("limitLower()", [40000]);
+          await mockVault.mockMethod("limitUpper()", [45000]);
+          await mockVault.mockMethod("period()", [86400]);
+          await mockVault.mockCall("setPeriod(uint32)", [0], []);
+          await mockVault.mockCall("setPeriod(uint32)", [86400], []);
+          await mockVault.mockMethod("rebalance()", []);
+          await manager.rebalance();
+
+          await mockVault.mockMethod("getTwap()", [70000]);
+          await mockVault.mockMethod("limitLower()", [75000]);
+          await mockVault.mockMethod("limitUpper()", [80000]);
+          await mockVault.clearMockMethod("emergencyBurn(int24,int24,uint128)");
+
+          expect(await manager.prevDeviation()).to.eq(percFP("1.115790573530244260"));
+          expect(await manager.isOverweightSpot()).to.eq(false);
+          await expect(manager.rebalance()).not.to.be.reverted;
+          expect(await manager.prevDeviation()).to.eq(percFP("0.913541191300990579"));
+        });
+      });
+    });
+
+    describe("when deviation remains below 1", function () {
+      describe("when overweight spot", function () {
+        it("should not force rebalance", async function () {
+          const { manager, mockVault, mockPool } = await loadFixture(setupContracts);
+
+          await mockVault.mockMethod("getTwap()", [70500]);
+          await mockVault.mockMethod("limitLower()", [40000]);
+          await mockVault.mockMethod("limitUpper()", [45000]);
+          await mockVault.mockMethod("rebalance()", []);
+          await mockPool.mockCall(
+            "positions(bytes32)",
+            [univ3PositionKey(mockVault.target, 40000, 45000)],
+            [50000, 0, 0, 0, 0],
+          );
+          await mockVault.mockCall(
+            "emergencyBurn(int24,int24,uint128)",
+            [40000, 45000, 50000],
+            [],
+          );
+
+          expect(await manager.prevDeviation()).to.eq("0");
+          expect(await manager.isOverweightSpot()).to.eq(true);
+          await expect(manager.rebalance()).not.to.be.reverted;
+          expect(await manager.prevDeviation()).to.eq(percFP("0.960377048978079093"));
+        });
+      });
+    });
+
+    describe("when deviation remains above 1", function () {
+      describe("when overweight usdc", function () {
+        it("should not force rebalance", async function () {
+          const { manager, mockVault, mockPool } = await loadFixture(setupContracts);
+
+          await mockVault.mockMethod("getTwap()", [72000]);
+          await mockVault.mockMethod("limitLower()", [40000]);
+          await mockVault.mockMethod("limitUpper()", [45000]);
+          await mockVault.mockMethod("period()", [86400]);
+          await mockVault.mockCall("setPeriod(uint32)", [0], []);
+          await mockVault.mockCall("setPeriod(uint32)", [86400], []);
+          await mockVault.mockMethod("rebalance()", []);
+          await manager.rebalance();
+
+          await mockVault.clearMockCall("setPeriod(uint32)", [0]);
+          await mockVault.clearMockCall("setPeriod(uint32)", [86400]);
+          await mockVault.clearMockCall("period()", []);
+          await mockVault.clearMockMethod("emergencyBurn(int24,int24,uint128)");
+
+          await mockVault.mockMethod("getTwap()", [71500]);
+          await mockVault.mockMethod("limitLower()", [75000]);
+          await mockVault.mockMethod("limitUpper()", [80000]);
+          await mockPool.mockCall(
+            "positions(bytes32)",
+            [univ3PositionKey(mockVault.target, 75000, 80000)],
+            [50000, 0, 0, 0, 0],
+          );
+          await mockVault.mockMethod("emergencyBurn(int24,int24,uint128)", []);
+
+          expect(await manager.prevDeviation()).to.eq(percFP("1.115790573530244260"));
+          expect(await manager.isOverweightSpot()).to.eq(false);
+          await expect(manager.rebalance()).not.to.be.reverted;
+          expect(await manager.prevDeviation()).to.eq(percFP("1.061375478380992817"));
+        });
+      });
+    });
+  });
+});

--- a/spot-vaults/test/WethWamplManager.ts
+++ b/spot-vaults/test/WethWamplManager.ts
@@ -20,17 +20,18 @@ describe("WethWamplManager", function () {
     // Deploy mock contracts
     const mockVault = new DMock("IAlphaProVault");
     await mockVault.deploy();
-    await mockVault.mockMethod("fullLower()", [-887200]);
-    await mockVault.mockMethod("fullUpper()", [887200]);
+    await mockVault.mockMethod("fullLower()", [-800000]);
+    await mockVault.mockMethod("fullUpper()", [800000]);
     await mockVault.mockMethod("baseLower()", [45000]);
     await mockVault.mockMethod("baseUpper()", [55000]);
     await mockVault.mockMethod("getTwap()", [49875]);
+    await mockVault.mockMethod("limitThreshold()", [800000]);
 
     const mockPool = new DMock("IUniswapV3Pool");
     await mockPool.deploy();
     await mockPool.mockCall(
       "positions(bytes32)",
-      [univ3PositionKey(mockVault.target, -887200, 887200)],
+      [univ3PositionKey(mockVault.target, -800000, 800000)],
       [100000, 0, 0, 0, 0],
     );
     await mockPool.mockCall(
@@ -93,56 +94,49 @@ describe("WethWamplManager", function () {
   describe("Initialization", function () {
     it("should set the correct owner", async function () {
       const { manager, owner } = await loadFixture(setupContracts);
-      expect(await manager.owner()).to.equal(await owner.getAddress());
+      expect(await manager.owner()).to.eq(await owner.getAddress());
     });
 
     it("should set the correct vault address", async function () {
       const { manager, mockVault } = await loadFixture(setupContracts);
-      expect(await manager.VAULT()).to.equal(mockVault.target);
+      expect(await manager.VAULT()).to.eq(mockVault.target);
     });
 
     it("should set the correct CPI oracle address", async function () {
       const { manager, mockCPIOracle } = await loadFixture(setupContracts);
-      expect(await manager.cpiOracle()).to.equal(mockCPIOracle.target);
+      expect(await manager.cpiOracle()).to.eq(mockCPIOracle.target);
     });
 
     it("should set the correct ETH oracle address", async function () {
       const { manager, mockETHOracle } = await loadFixture(setupContracts);
-      expect(await manager.ethOracle()).to.equal(mockETHOracle.target);
+      expect(await manager.ethOracle()).to.eq(mockETHOracle.target);
     });
 
     it("should set the token refs", async function () {
       const { manager, mockWeth, mockWampl, mockPool } = await loadFixture(
         setupContracts,
       );
-      expect(await manager.POOL()).to.equal(mockPool.target);
-      expect(await manager.WETH()).to.equal(mockWeth.target);
-      expect(await manager.WAMPL()).to.equal(mockWampl.target);
+      expect(await manager.POOL()).to.eq(mockPool.target);
+      expect(await manager.WETH()).to.eq(mockWeth.target);
+      expect(await manager.WAMPL()).to.eq(mockWampl.target);
     });
 
     it("should set the active perc calculation params", async function () {
       const { manager } = await loadFixture(setupContracts);
-      expect(await manager.deviationCutoff()).to.equal(percFP("1"));
-      expect(await manager.lastActiveLiqPerc()).to.equal(percFP("1"));
-      expect(await manager.tolerableActiveLiqPercDelta()).to.equal(percFP("0.1"));
+      expect(await manager.prevDeviation()).to.eq(percFP("0"));
+      expect(await manager.tolerableActiveLiqPercDelta()).to.eq(percFP("0.1"));
 
       const f1 = await manager.activeLiqPercFn1();
-      expect(f1[0]).to.equal(percFP("0.7"));
-      expect(f1[1]).to.equal(percFP("0.25"));
-      expect(f1[2]).to.equal(percFP("0.95"));
-      expect(f1[3]).to.equal(percFP("1"));
+      expect(f1[0]).to.eq(percFP("0.5"));
+      expect(f1[1]).to.eq(percFP("0.2"));
+      expect(f1[2]).to.eq(percFP("1"));
+      expect(f1[3]).to.eq(percFP("1"));
 
       const f2 = await manager.activeLiqPercFn2();
-      expect(f2[0]).to.equal(percFP("1.2"));
-      expect(f2[1]).to.equal(percFP("1"));
-      expect(f2[2]).to.equal(percFP("2.5"));
-      expect(f2[3]).to.equal(percFP("0.25"));
-    });
-
-    it("should set the limit threshold params", async function () {
-      const { manager } = await loadFixture(setupContracts);
-      expect(await manager.limitThresholdNarrow()).to.equal(3200);
-      expect(await manager.limitThresholdWide()).to.equal(887200);
+      expect(f2[0]).to.eq(percFP("1"));
+      expect(f2[1]).to.eq(percFP("1"));
+      expect(f2[2]).to.eq(percFP("2"));
+      expect(f2[3]).to.eq(percFP("0.2"));
     });
 
     it("should return the decimals", async function () {
@@ -162,7 +156,7 @@ describe("WethWamplManager", function () {
     it("should succeed when called by owner", async function () {
       const { manager, addr1 } = await loadFixture(setupContracts);
       await manager.transferOwnership(addr1.address);
-      expect(await manager.owner()).to.equal(await addr1.getAddress());
+      expect(await manager.owner()).to.eq(await addr1.getAddress());
     });
   });
 
@@ -177,7 +171,7 @@ describe("WethWamplManager", function () {
     it("should succeed when called by owner", async function () {
       const { manager, addr1 } = await loadFixture(setupContracts);
       await manager.setCpiOracle(addr1.address);
-      expect(await manager.cpiOracle()).to.equal(await addr1.getAddress());
+      expect(await manager.cpiOracle()).to.eq(await addr1.getAddress());
     });
   });
 
@@ -192,7 +186,7 @@ describe("WethWamplManager", function () {
     it("should succeed when called by owner", async function () {
       const { manager, addr1 } = await loadFixture(setupContracts);
       await manager.setEthOracle(addr1.address);
-      expect(await manager.ethOracle()).to.equal(await addr1.getAddress());
+      expect(await manager.ethOracle()).to.eq(await addr1.getAddress());
     });
   });
 
@@ -203,10 +197,9 @@ describe("WethWamplManager", function () {
         manager
           .connect(addr1)
           .setActivePercParams(
-            percFP("1.05"),
             percFP("0.05"),
-            [percFP("0.5"), percFP("0.05"), percFP("1.05"), percFP("1")],
-            [percFP("1.1"), percFP("1"), percFP("2"), percFP("0.1")],
+            [percFP("0.5"), percFP("0.2"), percFP("1"), percFP("1")],
+            [percFP("1"), percFP("1"), percFP("2"), percFP("0.2")],
           ),
       ).to.be.revertedWith("Unauthorized caller");
     });
@@ -214,26 +207,24 @@ describe("WethWamplManager", function () {
     it("should succeed when called by owner", async function () {
       const { manager } = await loadFixture(setupContracts);
       await manager.setActivePercParams(
-        percFP("1.05"),
         percFP("0.1"),
-        [percFP("0.5"), percFP("0.05"), percFP("1.05"), percFP("1")],
-        [percFP("1.1"), percFP("1"), percFP("2"), percFP("0.1")],
+        [percFP("0.5"), percFP("0.2"), percFP("1"), percFP("1")],
+        [percFP("1"), percFP("1"), percFP("2"), percFP("0.2")],
       );
 
-      expect(await manager.deviationCutoff()).to.equal(percFP("1.05"));
-      expect(await manager.tolerableActiveLiqPercDelta()).to.equal(percFP("0.1"));
+      expect(await manager.tolerableActiveLiqPercDelta()).to.eq(percFP("0.1"));
 
       const f1 = await manager.activeLiqPercFn1();
-      expect(f1[0]).to.equal(percFP("0.5"));
-      expect(f1[1]).to.equal(percFP("0.05"));
-      expect(f1[2]).to.equal(percFP("1.05"));
-      expect(f1[3]).to.equal(percFP("1"));
+      expect(f1[0]).to.eq(percFP("0.5"));
+      expect(f1[1]).to.eq(percFP("0.2"));
+      expect(f1[2]).to.eq(percFP("1"));
+      expect(f1[3]).to.eq(percFP("1"));
 
       const f2 = await manager.activeLiqPercFn2();
-      expect(f2[0]).to.equal(percFP("1.1"));
-      expect(f2[1]).to.equal(percFP("1"));
-      expect(f2[2]).to.equal(percFP("2"));
-      expect(f2[3]).to.equal(percFP("0.1"));
+      expect(f2[0]).to.eq(percFP("1"));
+      expect(f2[1]).to.eq(percFP("1"));
+      expect(f2[2]).to.eq(percFP("2"));
+      expect(f2[3]).to.eq(percFP("0.2"));
     });
   });
 
@@ -241,7 +232,7 @@ describe("WethWamplManager", function () {
     it("should fail to when called by non-owner", async function () {
       const { manager, addr1 } = await loadFixture(setupContracts);
       await expect(
-        manager.connect(addr1).setLiquidityRanges(7200, 330000, 1200, 100000),
+        manager.connect(addr1).setLiquidityRanges(7200, 330000, 1200),
       ).to.be.revertedWith("Unauthorized caller");
     });
 
@@ -249,10 +240,8 @@ describe("WethWamplManager", function () {
       const { manager, mockVault } = await loadFixture(setupContracts);
       await mockVault.mockCall("setBaseThreshold(int24)", [7200], []);
       await mockVault.mockCall("setFullRangeWeight(uint24)", [330000], []);
-      await mockVault.mockCall("setLimitThreshold(int24)", [100000], []);
-      await manager.setLiquidityRanges(7200, 330000, 1200, 100000);
-      expect(await manager.limitThresholdNarrow()).to.equal(1200);
-      expect(await manager.limitThresholdWide()).to.equal(100000);
+      await mockVault.mockCall("setLimitThreshold(int24)", [1200], []);
+      await manager.setLiquidityRanges(7200, 330000, 1200);
     });
   });
 
@@ -295,47 +284,73 @@ describe("WethWamplManager", function () {
   describe("#computeActiveLiqPerc", function () {
     it("should compute the active liquidity percentage", async function () {
       const { manager } = await loadFixture(setupContracts);
-      expect(await manager.computeActiveLiqPerc(percFP("0"))).to.eq(percFP("0.25"));
-      expect(await manager.computeActiveLiqPerc(percFP("0.5"))).to.eq(percFP("0.25"));
-      expect(await manager.computeActiveLiqPerc(percFP("0.73888888"))).to.eq(
-        percFP("0.36666664"),
-      );
-      expect(await manager.computeActiveLiqPerc(percFP("0.7425"))).to.eq(
-        percFP("0.3775"),
-      );
-      expect(await manager.computeActiveLiqPerc(percFP("0.75"))).to.eq(percFP("0.4"));
-      expect(await manager.computeActiveLiqPerc(percFP("0.8"))).to.eq(percFP("0.55"));
-      expect(await manager.computeActiveLiqPerc(percFP("0.85"))).to.eq(percFP("0.7"));
-      expect(await manager.computeActiveLiqPerc(percFP("0.9"))).to.eq(percFP("0.85"));
-      expect(await manager.computeActiveLiqPerc(percFP("0.95"))).to.eq(percFP("1"));
+      expect(await manager.computeActiveLiqPerc(percFP("0"))).to.eq(percFP("0.2"));
+      expect(await manager.computeActiveLiqPerc(percFP("0.5"))).to.eq(percFP("0.2"));
+      expect(await manager.computeActiveLiqPerc(percFP("0.75"))).to.eq(percFP("0.6"));
+      expect(await manager.computeActiveLiqPerc(percFP("0.95"))).to.eq(percFP("0.92"));
       expect(await manager.computeActiveLiqPerc(percFP("1"))).to.eq(percFP("1"));
-      expect(await manager.computeActiveLiqPerc(percFP("1.05"))).to.eq(percFP("1"));
-      expect(await manager.computeActiveLiqPerc(percFP("1.1"))).to.eq(percFP("1"));
-      expect(await manager.computeActiveLiqPerc(percFP("1.2"))).to.eq(percFP("1"));
-      expect(await manager.computeActiveLiqPerc(percFP("1.3"))).to.eq(
-        percFP("0.942307692307692307"),
-      );
-      expect(await manager.computeActiveLiqPerc(percFP("1.5"))).to.eq(
-        percFP("0.826923076923076923"),
-      );
-      expect(await manager.computeActiveLiqPerc(percFP("1.75"))).to.eq(
-        percFP("0.682692307692307692"),
-      );
-      expect(await manager.computeActiveLiqPerc(percFP("2"))).to.eq(
-        percFP("0.538461538461538461"),
-      );
-      expect(await manager.computeActiveLiqPerc(percFP("2.25"))).to.eq(
-        percFP("0.394230769230769230"),
-      );
-      expect(await manager.computeActiveLiqPerc(percFP("2.5"))).to.eq(percFP("0.25"));
-      expect(await manager.computeActiveLiqPerc(percFP("5"))).to.eq(percFP("0.25"));
-      expect(await manager.computeActiveLiqPerc(percFP("10"))).to.eq(percFP("0.25"));
-      expect(await manager.computeActiveLiqPerc(percFP("100000"))).to.eq(percFP("0.25"));
-      expect(await manager.computeActiveLiqPerc(ethers.MaxUint256)).to.eq(percFP("0.25"));
+      expect(await manager.computeActiveLiqPerc(percFP("1.05"))).to.eq(percFP("0.96"));
+      expect(await manager.computeActiveLiqPerc(percFP("1.25"))).to.eq(percFP("0.8"));
+      expect(await manager.computeActiveLiqPerc(percFP("1.5"))).to.eq(percFP("0.6"));
+      expect(await manager.computeActiveLiqPerc(percFP("1.75"))).to.eq(percFP("0.4"));
+      expect(await manager.computeActiveLiqPerc(percFP("2"))).to.eq(percFP("0.2"));
+      expect(await manager.computeActiveLiqPerc(percFP("2.5"))).to.eq(percFP("0.2"));
+      expect(await manager.computeActiveLiqPerc(percFP("5"))).to.eq(percFP("0.2"));
+      expect(await manager.computeActiveLiqPerc(percFP("10"))).to.eq(percFP("0.2"));
+      expect(await manager.computeActiveLiqPerc(percFP("100000"))).to.eq(percFP("0.2"));
+      expect(await manager.computeActiveLiqPerc(ethers.MaxUint256)).to.eq(percFP("0.2"));
     });
   });
 
   describe("#computeDeviationFactor", function () {
+    describe("when cpi is invalid", function () {
+      it("should return invalid", async function () {
+        const { manager, mockETHOracle, mockCPIOracle, mockWampl } = await loadFixture(
+          setupContracts,
+        );
+        await mockETHOracle.mockMethod("latestRoundData()", [
+          0,
+          ethOracleFP("3300"),
+          0,
+          nowTS(),
+          0,
+        ]);
+        await mockCPIOracle.mockMethod("getData()", [amplOracleFP("1.19"), false]);
+        await mockWampl.mockCall(
+          "wrapperToUnderlying(uint256)",
+          [wamplFP("1")],
+          [amplFP("18")],
+        );
+        const r = await manager.computeDeviationFactor.staticCall();
+        expect(r[0]).to.eq(percFP("1.051378374404781289"));
+        expect(r[1]).to.eq(false);
+      });
+    });
+
+    describe("when eth price is invalid", function () {
+      it("should return invalid", async function () {
+        const { manager, mockETHOracle, mockCPIOracle, mockWampl } = await loadFixture(
+          setupContracts,
+        );
+        await mockETHOracle.mockMethod("latestRoundData()", [
+          0,
+          ethOracleFP("3300"),
+          0,
+          nowTS() - 86400 * 7,
+          0,
+        ]);
+        await mockCPIOracle.mockMethod("getData()", [amplOracleFP("1.19"), true]);
+        await mockWampl.mockCall(
+          "wrapperToUnderlying(uint256)",
+          [wamplFP("1")],
+          [amplFP("18")],
+        );
+        const r = await manager.computeDeviationFactor.staticCall();
+        expect(r[0]).to.eq(percFP("1.051378374404781289"));
+        expect(r[1]).to.eq(false);
+      });
+    });
+
     it("should return deviation factor", async function () {
       const { manager, mockETHOracle, mockCPIOracle, mockWampl } = await loadFixture(
         setupContracts,
@@ -353,9 +368,9 @@ describe("WethWamplManager", function () {
         [wamplFP("1")],
         [amplFP("18")],
       );
-      expect(await manager.computeDeviationFactor.staticCall()).to.eq(
-        percFP("1.051378374404781289"),
-      );
+      const r = await manager.computeDeviationFactor.staticCall();
+      expect(r[0]).to.eq(percFP("1.051378374404781289"));
+      expect(r[1]).to.eq(true);
     });
 
     it("should return deviation factor", async function () {
@@ -375,9 +390,9 @@ describe("WethWamplManager", function () {
         [wamplFP("1")],
         [amplFP("10")],
       );
-      expect(await manager.computeDeviationFactor.staticCall()).to.eq(
-        percFP("1.892481073928606322"),
-      );
+      const r = await manager.computeDeviationFactor.staticCall();
+      expect(r[0]).to.eq(percFP("1.892481073928606322"));
+      expect(r[1]).to.eq(true);
     });
 
     it("should return deviation factor", async function () {
@@ -397,49 +412,9 @@ describe("WethWamplManager", function () {
         [wamplFP("1")],
         [amplFP("25")],
       );
-      expect(await manager.computeDeviationFactor.staticCall()).to.eq(
-        percFP("0.756992429571442528"),
-      );
-    });
-
-    it("should return 0 if eth price is invalid", async function () {
-      const { manager, mockETHOracle, mockCPIOracle, mockWampl } = await loadFixture(
-        setupContracts,
-      );
-      await mockETHOracle.mockMethod("latestRoundData()", [
-        0,
-        ethOracleFP("3300"),
-        0,
-        nowTS() - 86400 * 2,
-        0,
-      ]);
-      await mockCPIOracle.mockMethod("getData()", [amplOracleFP("1.19"), true]);
-      await mockWampl.mockCall(
-        "wrapperToUnderlying(uint256)",
-        [wamplFP("1")],
-        [amplFP("18")],
-      );
-      expect(await manager.computeDeviationFactor.staticCall()).to.eq("0");
-    });
-
-    it("should return 0 if cpi target is invalid", async function () {
-      const { manager, mockETHOracle, mockCPIOracle, mockWampl } = await loadFixture(
-        setupContracts,
-      );
-      await mockETHOracle.mockMethod("latestRoundData()", [
-        0,
-        ethOracleFP("3300"),
-        0,
-        nowTS(),
-        0,
-      ]);
-      await mockCPIOracle.mockMethod("getData()", [amplOracleFP("1.19"), false]);
-      await mockWampl.mockCall(
-        "wrapperToUnderlying(uint256)",
-        [wamplFP("1")],
-        [amplFP("18")],
-      );
-      expect(await manager.computeDeviationFactor.staticCall()).to.eq("0");
+      const r = await manager.computeDeviationFactor.staticCall();
+      expect(r[0]).to.eq(percFP("0.756992429571442528"));
+      expect(r[1]).to.eq(true);
     });
 
     it("should return max deviation when price is too high", async function () {
@@ -459,137 +434,447 @@ describe("WethWamplManager", function () {
         [wamplFP("1")],
         [amplFP("18")],
       );
-      expect(await manager.computeDeviationFactor.staticCall()).to.eq(percFP("100"));
+      const r = await manager.computeDeviationFactor.staticCall();
+      expect(r[0]).to.eq(percFP("100"));
+      expect(r[1]).to.eq(true);
     });
   });
 
-  describe("inNarrowLimitRange", function () {
-    describe("when wampl sell, dr > 1", function () {
+  describe("isOverweightWampl", function () {
+    describe("when wampl sell", function () {
       it("should return true", async function () {
         const { manager, mockVault } = await loadFixture(setupContracts);
         await mockVault.mockMethod("getTwap()", [30001]);
         await mockVault.mockMethod("limitLower()", [20000]);
         await mockVault.mockMethod("limitUpper()", [40000]);
-        expect(await manager.inNarrowLimitRange(percFP("1.1"))).to.eq(true);
+        expect(await manager.isOverweightWampl()).to.eq(true);
       });
     });
 
-    describe("when wampl sell, dr < 1", function () {
+    describe("when wampl buy", function () {
       it("should return false", async function () {
         const { manager, mockVault } = await loadFixture(setupContracts);
-        await mockVault.mockMethod("getTwap()", [30001]);
-        await mockVault.mockMethod("limitLower()", [20000]);
-        await mockVault.mockMethod("limitUpper()", [40000]);
-        expect(await manager.inNarrowLimitRange(percFP("0.9"))).to.eq(false);
-      });
-    });
-
-    describe("when wampl buy, dr > 1", function () {
-      it("should return true", async function () {
-        const { manager, mockVault } = await loadFixture(setupContracts);
         await mockVault.mockMethod("getTwap()", [29999]);
         await mockVault.mockMethod("limitLower()", [20000]);
         await mockVault.mockMethod("limitUpper()", [40000]);
-        expect(await manager.inNarrowLimitRange(percFP("1.1"))).to.eq(false);
-      });
-    });
-
-    describe("when wampl buy, dr < 1", function () {
-      it("should return true", async function () {
-        const { manager, mockVault } = await loadFixture(setupContracts);
-        await mockVault.mockMethod("getTwap()", [29999]);
-        await mockVault.mockMethod("limitLower()", [20000]);
-        await mockVault.mockMethod("limitUpper()", [40000]);
-        expect(await manager.inNarrowLimitRange(percFP("0.9"))).to.eq(true);
+        expect(await manager.isOverweightWampl()).to.eq(false);
       });
     });
   });
 
   describe("#rebalance", function () {
-    describe("when in narrow range", function () {
-      it("should update the limit threshold", async function () {
-        const { manager, mockVault } = await loadFixture(setupContracts);
-        await mockVault.mockMethod("limitLower()", [45000]);
-        await mockVault.mockMethod("limitUpper()", [50000]);
-        await mockVault.mockMethod("rebalance()", []);
-        await mockVault.mockCall("setLimitThreshold(int24)", [3200], []);
-        await mockVault.mockMethod("emergencyBurn(int24,int24,uint128)", []);
-        await expect(manager.rebalance()).not.to.be.reverted;
+    describe("when activePercDelta is within threshold", function () {
+      describe("when deviation is < 1 and goes > 1", function () {
+        describe("when overweight wampl", function () {
+          it("should trim liquidity & keep limit range", async function () {
+            const { manager, mockVault } = await loadFixture(setupContracts);
+            await manager.setActivePercParams(
+              percFP("1"),
+              [percFP("0.5"), percFP("0.2"), percFP("1"), percFP("1")],
+              [percFP("1"), percFP("1"), percFP("2"), percFP("0.2")],
+            );
+
+            await mockVault.mockMethod("getTwap()", [49500]);
+            await mockVault.mockMethod("limitLower()", [40000]);
+            await mockVault.mockMethod("limitUpper()", [45000]);
+            await mockVault.mockMethod("period()", [86400]);
+            await mockVault.mockCall("setPeriod(uint32)", [0], []);
+            await mockVault.mockCall("setPeriod(uint32)", [86400], []);
+            await mockVault.mockMethod("rebalance()", []);
+
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [-800000, 800000, 7324],
+              [],
+            );
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [45000, 55000, 1464],
+              [],
+            );
+
+            expect(await manager.prevDeviation()).to.eq("0");
+            expect(await manager.isOverweightWampl()).to.eq(true);
+            await expect(manager.rebalance()).not.to.be.reverted;
+            expect(await manager.prevDeviation()).to.eq(percFP("1.091551595254704898"));
+          });
+        });
+
+        describe("when overweight weth", function () {
+          it("should trim liquidity & remove limit range", async function () {
+            const { manager, mockVault, mockPool } = await loadFixture(setupContracts);
+            await manager.setActivePercParams(
+              percFP("1"),
+              [percFP("0.5"), percFP("0.2"), percFP("1"), percFP("1")],
+              [percFP("1"), percFP("1"), percFP("2"), percFP("0.2")],
+            );
+
+            await mockVault.mockMethod("getTwap()", [49500]);
+            await mockVault.mockMethod("limitLower()", [50000]);
+            await mockVault.mockMethod("limitUpper()", [55000]);
+            await mockPool.mockCall(
+              "positions(bytes32)",
+              [univ3PositionKey(mockVault.target, 50000, 55000)],
+              [50000, 0, 0, 0, 0],
+            );
+
+            await mockVault.mockMethod("period()", [86400]);
+            await mockVault.mockCall("setPeriod(uint32)", [0], []);
+            await mockVault.mockCall("setPeriod(uint32)", [86400], []);
+            await mockVault.mockMethod("rebalance()", []);
+
+            await mockVault.clearMockMethod("emergencyBurn(int24,int24,uint128)");
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [-800000, 800000, 7324],
+              [],
+            );
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [45000, 55000, 1464],
+              [],
+            );
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [50000, 55000, 50000],
+              [],
+            );
+
+            expect(await manager.prevDeviation()).to.eq("0");
+            expect(await manager.isOverweightWampl()).to.eq(false);
+            await expect(manager.rebalance()).not.to.be.reverted;
+            expect(await manager.prevDeviation()).to.eq(percFP("1.091551595254704898"));
+          });
+        });
+      });
+
+      describe("when deviation is > 1 and goes < 1", function () {
+        describe("when overweight wampl", function () {
+          it("should trim liquidity & remove limit range", async function () {
+            const { manager, mockVault, mockPool } = await loadFixture(setupContracts);
+            await manager.setActivePercParams(
+              percFP("1"),
+              [percFP("0.5"), percFP("0.2"), percFP("1"), percFP("1")],
+              [percFP("1"), percFP("1"), percFP("2"), percFP("0.2")],
+            );
+
+            await mockVault.mockMethod("getTwap()", [49500]);
+            await mockVault.mockMethod("limitLower()", [40000]);
+            await mockVault.mockMethod("limitUpper()", [45000]);
+            await mockVault.mockMethod("period()", [86400]);
+            await mockVault.mockCall("setPeriod(uint32)", [0], []);
+            await mockVault.mockCall("setPeriod(uint32)", [86400], []);
+            await mockVault.mockMethod("rebalance()", []);
+            await mockVault.mockMethod("emergencyBurn(int24,int24,uint128)", []);
+            await manager.rebalance();
+
+            await mockVault.mockMethod("getTwap()", [52000]);
+            await mockVault.mockMethod("limitLower()", [50000]);
+            await mockVault.mockMethod("limitUpper()", [51000]);
+            await mockPool.mockCall(
+              "positions(bytes32)",
+              [univ3PositionKey(mockVault.target, 50000, 51000)],
+              [50000, 0, 0, 0, 0],
+            );
+
+            await mockVault.clearMockMethod("emergencyBurn(int24,int24,uint128)");
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [-800000, 800000, 23982],
+              [],
+            );
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [45000, 55000, 4796],
+              [],
+            );
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [50000, 51000, 50000],
+              [],
+            );
+
+            expect(await manager.prevDeviation()).to.eq(percFP("1.091551595254704898"));
+            expect(await manager.isOverweightWampl()).to.eq(true);
+            await expect(manager.rebalance()).not.to.be.reverted;
+            expect(await manager.prevDeviation()).to.eq(percFP("0.850111862770710708"));
+          });
+        });
+
+        describe("when overweight weth", function () {
+          it("should trim liquidity & keep limit range", async function () {
+            const { manager, mockVault } = await loadFixture(setupContracts);
+            await manager.setActivePercParams(
+              percFP("1"),
+              [percFP("0.5"), percFP("0.2"), percFP("1"), percFP("1")],
+              [percFP("1"), percFP("1"), percFP("2"), percFP("0.2")],
+            );
+
+            await mockVault.mockMethod("getTwap()", [49500]);
+            await mockVault.mockMethod("limitLower()", [40000]);
+            await mockVault.mockMethod("limitUpper()", [45000]);
+            await mockVault.mockMethod("period()", [86400]);
+            await mockVault.mockCall("setPeriod(uint32)", [0], []);
+            await mockVault.mockCall("setPeriod(uint32)", [86400], []);
+            await mockVault.mockMethod("rebalance()", []);
+            await mockVault.mockMethod("emergencyBurn(int24,int24,uint128)", []);
+            await manager.rebalance();
+
+            await mockVault.mockMethod("getTwap()", [52000]);
+            await mockVault.mockMethod("limitLower()", [53000]);
+            await mockVault.mockMethod("limitUpper()", [55000]);
+
+            await mockVault.clearMockMethod("emergencyBurn(int24,int24,uint128)");
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [-800000, 800000, 23982],
+              [],
+            );
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [45000, 55000, 4796],
+              [],
+            );
+
+            expect(await manager.prevDeviation()).to.eq(percFP("1.091551595254704898"));
+            expect(await manager.isOverweightWampl()).to.eq(false);
+            await expect(manager.rebalance()).not.to.be.reverted;
+            expect(await manager.prevDeviation()).to.eq(percFP("0.850111862770710708"));
+          });
+        });
       });
     });
 
-    describe("when in wide range", function () {
-      it("should update the limit threshold", async function () {
-        const { manager, mockVault } = await loadFixture(setupContracts);
-        await mockVault.mockMethod("limitLower()", [55000]);
-        await mockVault.mockMethod("limitUpper()", [60000]);
-        await mockVault.mockMethod("rebalance()", []);
-        await mockVault.mockCall("setLimitThreshold(int24)", [887200], []);
-        await mockVault.mockMethod("emergencyBurn(int24,int24,uint128)", []);
-        await expect(manager.rebalance()).not.to.be.reverted;
+    describe("when activePercDelta is outside threshold", function () {
+      describe("when deviation is < 1 and goes > 1", function () {
+        describe("when overweight wampl", function () {
+          it("should trim liquidity & keep limit range", async function () {
+            const { manager, mockVault } = await loadFixture(setupContracts);
+
+            await mockVault.mockMethod("getTwap()", [49500]);
+            await mockVault.mockMethod("limitLower()", [40000]);
+            await mockVault.mockMethod("limitUpper()", [45000]);
+            await mockVault.mockMethod("period()", [86400]);
+            await mockVault.mockCall("setPeriod(uint32)", [0], []);
+            await mockVault.mockCall("setPeriod(uint32)", [86400], []);
+            await mockVault.mockMethod("rebalance()", []);
+
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [-800000, 800000, 7324],
+              [],
+            );
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [45000, 55000, 1464],
+              [],
+            );
+
+            expect(await manager.prevDeviation()).to.eq("0");
+            expect(await manager.isOverweightWampl()).to.eq(true);
+            await expect(manager.rebalance()).not.to.be.reverted;
+            expect(await manager.prevDeviation()).to.eq(percFP("1.091551595254704898"));
+          });
+        });
+
+        describe("when overweight weth", function () {
+          it("should trim liquidity & remove limit range", async function () {
+            const { manager, mockVault, mockPool } = await loadFixture(setupContracts);
+
+            await mockVault.mockMethod("getTwap()", [49500]);
+            await mockVault.mockMethod("limitLower()", [50000]);
+            await mockVault.mockMethod("limitUpper()", [55000]);
+            await mockPool.mockCall(
+              "positions(bytes32)",
+              [univ3PositionKey(mockVault.target, 50000, 55000)],
+              [50000, 0, 0, 0, 0],
+            );
+
+            await mockVault.mockMethod("period()", [86400]);
+            await mockVault.mockCall("setPeriod(uint32)", [0], []);
+            await mockVault.mockCall("setPeriod(uint32)", [86400], []);
+            await mockVault.mockMethod("rebalance()", []);
+
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [-800000, 800000, 7324],
+              [],
+            );
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [45000, 55000, 1464],
+              [],
+            );
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [50000, 55000, 50000],
+              [],
+            );
+
+            expect(await manager.prevDeviation()).to.eq("0");
+            expect(await manager.isOverweightWampl()).to.eq(false);
+            await expect(manager.rebalance()).not.to.be.reverted;
+            expect(await manager.prevDeviation()).to.eq(percFP("1.091551595254704898"));
+          });
+        });
+      });
+
+      describe("when deviation is > 1 and goes < 1", function () {
+        describe("when overweight wampl", function () {
+          it("should trim liquidity & remove limit range", async function () {
+            const { manager, mockVault, mockPool } = await loadFixture(setupContracts);
+
+            await mockVault.mockMethod("getTwap()", [49500]);
+            await mockVault.mockMethod("limitLower()", [40000]);
+            await mockVault.mockMethod("limitUpper()", [45000]);
+            await mockVault.mockMethod("period()", [86400]);
+            await mockVault.mockCall("setPeriod(uint32)", [0], []);
+            await mockVault.mockCall("setPeriod(uint32)", [86400], []);
+            await mockVault.mockMethod("rebalance()", []);
+            await mockVault.mockMethod("emergencyBurn(int24,int24,uint128)", []);
+            await manager.rebalance();
+
+            await mockVault.mockMethod("getTwap()", [52000]);
+            await mockVault.mockMethod("limitLower()", [50000]);
+            await mockVault.mockMethod("limitUpper()", [51000]);
+            await mockPool.mockCall(
+              "positions(bytes32)",
+              [univ3PositionKey(mockVault.target, 50000, 51000)],
+              [50000, 0, 0, 0, 0],
+            );
+            await mockVault.clearMockMethod("emergencyBurn(int24,int24,uint128)");
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [-800000, 800000, 23982],
+              [],
+            );
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [45000, 55000, 4796],
+              [],
+            );
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [50000, 51000, 50000],
+              [],
+            );
+
+            expect(await manager.prevDeviation()).to.eq(percFP("1.091551595254704898"));
+            expect(await manager.isOverweightWampl()).to.eq(true);
+            await expect(manager.rebalance()).not.to.be.reverted;
+            expect(await manager.prevDeviation()).to.eq(percFP("0.850111862770710708"));
+          });
+        });
+
+        describe("when overweight weth", function () {
+          it("should trim liquidity & keep limit range", async function () {
+            const { manager, mockVault } = await loadFixture(setupContracts);
+
+            await mockVault.mockMethod("getTwap()", [49500]);
+            await mockVault.mockMethod("limitLower()", [40000]);
+            await mockVault.mockMethod("limitUpper()", [45000]);
+            await mockVault.mockMethod("period()", [86400]);
+            await mockVault.mockCall("setPeriod(uint32)", [0], []);
+            await mockVault.mockCall("setPeriod(uint32)", [86400], []);
+            await mockVault.mockMethod("rebalance()", []);
+            await mockVault.mockMethod("emergencyBurn(int24,int24,uint128)", []);
+            await manager.rebalance();
+
+            await mockVault.mockMethod("getTwap()", [52000]);
+            await mockVault.mockMethod("limitLower()", [53000]);
+            await mockVault.mockMethod("limitUpper()", [55000]);
+
+            await mockVault.clearMockMethod("emergencyBurn(int24,int24,uint128)");
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [-800000, 800000, 23982],
+              [],
+            );
+            await mockVault.mockCall(
+              "emergencyBurn(int24,int24,uint128)",
+              [45000, 55000, 4796],
+              [],
+            );
+
+            expect(await manager.prevDeviation()).to.eq(percFP("1.091551595254704898"));
+            expect(await manager.isOverweightWampl()).to.eq(false);
+            await expect(manager.rebalance()).not.to.be.reverted;
+            expect(await manager.prevDeviation()).to.eq(percFP("0.850111862770710708"));
+          });
+        });
       });
     });
 
-    describe("when outside active perc threshold", function () {
-      it("should exec force rebalance", async function () {
-        const { manager, mockVault, mockCPIOracle } = await loadFixture(setupContracts);
-        await mockVault.mockMethod("limitLower()", [45000]);
-        await mockVault.mockMethod("limitUpper()", [50000]);
-        await mockVault.mockCall("setLimitThreshold(int24)", [887200], []);
-        await mockCPIOracle.mockMethod("getData()", [amplOracleFP("1.5"), true]);
-        await mockVault.mockMethod("emergencyBurn(int24,int24,uint128)", []);
-        await mockVault.mockMethod("period()", [86400]);
-        await mockVault.mockCall("setPeriod(uint32)", [0], []);
-        await mockVault.mockCall("setPeriod(uint32)", [86400], []);
-        await mockVault.mockMethod("rebalance()", []);
-        await expect(manager.rebalance()).not.to.be.reverted;
+    describe("when deviation remains below 1", function () {
+      describe("when overweight wampl", function () {
+        it("should not force rebalance", async function () {
+          const { manager, mockVault, mockPool } = await loadFixture(setupContracts);
+          await manager.setActivePercParams(
+            percFP("1"),
+            [percFP("0.5"), percFP("0.2"), percFP("1"), percFP("1")],
+            [percFP("1"), percFP("1"), percFP("2"), percFP("0.2")],
+          );
+
+          await mockVault.mockMethod("getTwap()", [51500]);
+          await mockVault.mockMethod("limitLower()", [40000]);
+          await mockVault.mockMethod("limitUpper()", [45000]);
+          await mockPool.mockCall(
+            "positions(bytes32)",
+            [univ3PositionKey(mockVault.target, 40000, 45000)],
+            [50000, 0, 0, 0, 0],
+          );
+          await mockVault.mockMethod("rebalance()", []);
+          await mockVault.mockMethod("emergencyBurn(int24,int24,uint128)", []);
+
+          expect(await manager.prevDeviation()).to.eq("0");
+          expect(await manager.isOverweightWampl()).to.eq(true);
+          await expect(manager.rebalance()).not.to.be.reverted;
+          expect(await manager.prevDeviation()).to.eq(percFP("0.893695795923885030"));
+        });
       });
     });
 
-    describe("when inside active perc threshold", function () {
-      it("should exec rebalance", async function () {
-        const { manager, mockVault, mockCPIOracle } = await loadFixture(setupContracts);
-        await mockVault.mockMethod("limitLower()", [45000]);
-        await mockVault.mockMethod("limitUpper()", [50000]);
-        await mockVault.mockCall("setLimitThreshold(int24)", [887200], []);
-        await mockCPIOracle.mockMethod("getData()", [amplOracleFP("1.35"), true]);
-        await mockVault.mockMethod("emergencyBurn(int24,int24,uint128)", []);
-        await mockVault.mockMethod("rebalance()", []);
-        await expect(manager.rebalance()).not.to.be.reverted;
+    describe("when deviation remains above 1", function () {
+      describe("when overweight weth", function () {
+        it("should not force rebalance", async function () {
+          const { manager, mockVault, mockPool } = await loadFixture(setupContracts);
+          await manager.setActivePercParams(
+            percFP("1"),
+            [percFP("0.5"), percFP("0.2"), percFP("1"), percFP("1")],
+            [percFP("1"), percFP("1"), percFP("2"), percFP("0.2")],
+          );
+
+          await mockVault.mockMethod("getTwap()", [49500]);
+          await mockVault.mockMethod("limitLower()", [40000]);
+          await mockVault.mockMethod("limitUpper()", [45000]);
+          await mockVault.mockMethod("period()", [86400]);
+          await mockVault.mockCall("setPeriod(uint32)", [0], []);
+          await mockVault.mockCall("setPeriod(uint32)", [86400], []);
+          await mockVault.mockMethod("rebalance()", []);
+          await mockVault.mockMethod("emergencyBurn(int24,int24,uint128)", []);
+          await manager.rebalance();
+
+          await mockVault.clearMockCall("setPeriod(uint32)", [0]);
+          await mockVault.clearMockCall("setPeriod(uint32)", [86400]);
+          await mockVault.clearMockCall("period()", []);
+          await mockVault.clearMockMethod("emergencyBurn(int24,int24,uint128)");
+
+          await mockVault.mockMethod("getTwap()", [50000]);
+          await mockVault.mockMethod("limitLower()", [53000]);
+          await mockVault.mockMethod("limitUpper()", [55000]);
+          await mockPool.mockCall(
+            "positions(bytes32)",
+            [univ3PositionKey(mockVault.target, 53000, 55000)],
+            [50000, 0, 0, 0, 0],
+          );
+          await mockVault.mockMethod("emergencyBurn(int24,int24,uint128)", []);
+
+          expect(await manager.prevDeviation()).to.eq(percFP("1.091551595254704898"));
+          expect(await manager.isOverweightWampl()).to.eq(false);
+          await expect(manager.rebalance()).not.to.be.reverted;
+          expect(await manager.prevDeviation()).to.eq(percFP("1.038318591387163286"));
+        });
       });
-    });
-
-    it("should trim liquidity", async function () {
-      const { manager, mockVault } = await loadFixture(setupContracts);
-      await mockVault.mockMethod("limitLower()", [45000]);
-      await mockVault.mockMethod("limitUpper()", [55000]);
-      await mockVault.mockCall("setLimitThreshold(int24)", [887200], []);
-      await mockVault.mockMethod("getTwap()", [47500]);
-      await mockVault.mockMethod("rebalance()", []);
-      // activePerc = ~0.92
-      await mockVault.mockCall(
-        "emergencyBurn(int24,int24,uint128)",
-        [-887200, 887200, 7685],
-        [],
-      );
-      await mockVault.mockCall(
-        "emergencyBurn(int24,int24,uint128)",
-        [45000, 55000, 1537],
-        [],
-      );
-      await expect(manager.rebalance()).not.to.be.reverted;
-    });
-
-    it("should update the active perc", async function () {
-      const { manager, mockVault } = await loadFixture(setupContracts);
-      await mockVault.mockMethod("limitLower()", [45000]);
-      await mockVault.mockMethod("limitUpper()", [55000]);
-      await mockVault.mockCall("setLimitThreshold(int24)", [887200], []);
-      await mockVault.mockMethod("getTwap()", [47500]);
-      await mockVault.mockMethod("rebalance()", []);
-      await mockVault.mockMethod("emergencyBurn(int24,int24,uint128)", []);
-      await expect(manager.rebalance()).not.to.be.reverted;
-      expect(await manager.lastActiveLiqPerc()).to.eq(percFP("0.923147616635188312"));
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,7 +157,7 @@ __metadata:
     ethers: ^6.6.0
     ethers-v5: "npm:ethers@^5.7.0"
     ganache-cli: latest
-    hardhat: ^2.22.1
+    hardhat: ^2.22.6
     hardhat-gas-reporter: latest
     lodash: ^4.17.21
     prettier: ^2.7.1
@@ -1341,10 +1341,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nomicfoundation/edr-darwin-arm64@npm:0.4.2":
+  version: 0.4.2
+  resolution: "@nomicfoundation/edr-darwin-arm64@npm:0.4.2"
+  checksum: 7835e998c2ef83924efac0694bb4392f6abf770dc7f935dd28abc1a291f830cade14750d83a46a3205338e4ddff943dda60a9849317cf42edd38d7a2ce843588
+  languageName: node
+  linkType: hard
+
 "@nomicfoundation/edr-darwin-x64@npm:0.4.1":
   version: 0.4.1
   resolution: "@nomicfoundation/edr-darwin-x64@npm:0.4.1"
   checksum: bd02d7f19f762efe92c7abc7b56372c85689d810de0c97c74467f5431547d593b8ce69244675d96e682db8be4ff487c29c63b163e8878f5b541b21cb713fa9ab
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-darwin-x64@npm:0.4.2":
+  version: 0.4.2
+  resolution: "@nomicfoundation/edr-darwin-x64@npm:0.4.2"
+  checksum: 94daa26610621e85cb025feb37bb93e9b89c59f908bf3eae70720d2b86632dbb1236420ae3ae6f685d563ba52519d5f860e68ccd898fa1fced831961dea2c08a
   languageName: node
   linkType: hard
 
@@ -1355,10 +1369,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nomicfoundation/edr-linux-arm64-gnu@npm:0.4.2":
+  version: 0.4.2
+  resolution: "@nomicfoundation/edr-linux-arm64-gnu@npm:0.4.2"
+  checksum: a7181e237f6ece8bd97e0f75972044dbf584c506bbac5bef586d9f7d627a2c07a279a2d892837bbedc80ea3dfb39fa66becc297238b5d715a942eed2a50745cd
+  languageName: node
+  linkType: hard
+
 "@nomicfoundation/edr-linux-arm64-musl@npm:0.4.1":
   version: 0.4.1
   resolution: "@nomicfoundation/edr-linux-arm64-musl@npm:0.4.1"
   checksum: d4fb68393f93b0dca040ae3aff339ca83c94a4e12b54b3839b67ba699cc2ef4431cad6af38ae0c7c4c7a0fce0880cbf86d2092743e87e8dbb40074ec63431154
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-linux-arm64-musl@npm:0.4.2":
+  version: 0.4.2
+  resolution: "@nomicfoundation/edr-linux-arm64-musl@npm:0.4.2"
+  checksum: 5a849484b7a104a7e1497774c4117afc58f64d57d30889d4f6f676dddb5c695192c0789b8be0b71171a2af770167a28aa301ae3ece7a2a156d82d94388639b66
   languageName: node
   linkType: hard
 
@@ -1369,6 +1397,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nomicfoundation/edr-linux-x64-gnu@npm:0.4.2":
+  version: 0.4.2
+  resolution: "@nomicfoundation/edr-linux-x64-gnu@npm:0.4.2"
+  checksum: 0520dd9a583976fd0f49dfe6c23227f03cd811a395dc5eed1a2922b4358d7c71fdcfea8f389d4a0e23b4ec53e1435959a544380f94e48122a75f94a42b177ac7
+  languageName: node
+  linkType: hard
+
 "@nomicfoundation/edr-linux-x64-musl@npm:0.4.1":
   version: 0.4.1
   resolution: "@nomicfoundation/edr-linux-x64-musl@npm:0.4.1"
@@ -1376,10 +1411,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nomicfoundation/edr-linux-x64-musl@npm:0.4.2":
+  version: 0.4.2
+  resolution: "@nomicfoundation/edr-linux-x64-musl@npm:0.4.2"
+  checksum: 80c3b4346d8c27539bc005b09db233dedd8930310d1a049827661e69a8e03be9cbac27eb620a6ae9bfd46a2fbe22f83cee5af8d9e63178925d74d9c656246708
+  languageName: node
+  linkType: hard
+
 "@nomicfoundation/edr-win32-x64-msvc@npm:0.4.1":
   version: 0.4.1
   resolution: "@nomicfoundation/edr-win32-x64-msvc@npm:0.4.1"
   checksum: 0c2081ad3d2ce60f0ef8fd5aa876d070568fa038b371859d9d253c072c8db7d66674fa9ea1c722915a434e04a0a46463821bbea97e6bf577c50ec3def3819309
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-win32-x64-msvc@npm:0.4.2":
+  version: 0.4.2
+  resolution: "@nomicfoundation/edr-win32-x64-msvc@npm:0.4.2"
+  checksum: 736fb866fd5c2708560cbd5ae72815b5fc96e650cd74bc8bab0a1cb0e8baede4f595fdceb445c159814a6a7e8e691de227a5db49f61b3cd0ddfafd5715b397ab
   languageName: node
   linkType: hard
 
@@ -1395,6 +1444,21 @@ __metadata:
     "@nomicfoundation/edr-linux-x64-musl": 0.4.1
     "@nomicfoundation/edr-win32-x64-msvc": 0.4.1
   checksum: e3798101748df5d158a509e331c47754646071738721e10a30da95046066a61d4435de4e47e179279ce51ebb2f6e81bd0c9125f367c58bd46fca1abb0d0ee0dd
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr@npm:^0.4.1":
+  version: 0.4.2
+  resolution: "@nomicfoundation/edr@npm:0.4.2"
+  dependencies:
+    "@nomicfoundation/edr-darwin-arm64": 0.4.2
+    "@nomicfoundation/edr-darwin-x64": 0.4.2
+    "@nomicfoundation/edr-linux-arm64-gnu": 0.4.2
+    "@nomicfoundation/edr-linux-arm64-musl": 0.4.2
+    "@nomicfoundation/edr-linux-x64-gnu": 0.4.2
+    "@nomicfoundation/edr-linux-x64-musl": 0.4.2
+    "@nomicfoundation/edr-win32-x64-msvc": 0.4.2
+  checksum: 8c8457257b59ed9a29d88b7492e98e974d24e8318903e876a14dc0f6d5dc77948cd9053937d9730f54f920ba82ce3d244cab518d068359bcc20df88623f171ef
   languageName: node
   linkType: hard
 
@@ -9196,7 +9260,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hardhat@npm:^2.19.4, hardhat@npm:^2.22.1":
+"hardhat@npm:^2.19.4":
   version: 2.22.5
   resolution: "hardhat@npm:2.22.5"
   dependencies:
@@ -9254,6 +9318,67 @@ __metadata:
   bin:
     hardhat: internal/cli/bootstrap.js
   checksum: 34ab9ae3820c26ea4c92db43aefb15668d0575787d214a408b3274d445a7626775f2966dca2cf82a8fa8d9f39ebfdc90f3fb7189409b9582e373ce5b66ec3855
+  languageName: node
+  linkType: hard
+
+"hardhat@npm:^2.22.6":
+  version: 2.22.6
+  resolution: "hardhat@npm:2.22.6"
+  dependencies:
+    "@ethersproject/abi": ^5.1.2
+    "@metamask/eth-sig-util": ^4.0.0
+    "@nomicfoundation/edr": ^0.4.1
+    "@nomicfoundation/ethereumjs-common": 4.0.4
+    "@nomicfoundation/ethereumjs-tx": 5.0.4
+    "@nomicfoundation/ethereumjs-util": 9.0.4
+    "@nomicfoundation/solidity-analyzer": ^0.1.0
+    "@sentry/node": ^5.18.1
+    "@types/bn.js": ^5.1.0
+    "@types/lru-cache": ^5.1.0
+    adm-zip: ^0.4.16
+    aggregate-error: ^3.0.0
+    ansi-escapes: ^4.3.0
+    boxen: ^5.1.2
+    chalk: ^2.4.2
+    chokidar: ^3.4.0
+    ci-info: ^2.0.0
+    debug: ^4.1.1
+    enquirer: ^2.3.0
+    env-paths: ^2.2.0
+    ethereum-cryptography: ^1.0.3
+    ethereumjs-abi: ^0.6.8
+    find-up: ^2.1.0
+    fp-ts: 1.19.3
+    fs-extra: ^7.0.1
+    glob: 7.2.0
+    immutable: ^4.0.0-rc.12
+    io-ts: 1.10.4
+    keccak: ^3.0.2
+    lodash: ^4.17.11
+    mnemonist: ^0.38.0
+    mocha: ^10.0.0
+    p-map: ^4.0.0
+    raw-body: ^2.4.1
+    resolve: 1.17.0
+    semver: ^6.3.0
+    solc: 0.8.26
+    source-map-support: ^0.5.13
+    stacktrace-parser: ^0.1.10
+    tsort: 0.0.1
+    undici: ^5.14.0
+    uuid: ^8.3.2
+    ws: ^7.4.6
+  peerDependencies:
+    ts-node: "*"
+    typescript: "*"
+  peerDependenciesMeta:
+    ts-node:
+      optional: true
+    typescript:
+      optional: true
+  bin:
+    hardhat: internal/cli/bootstrap.js
+  checksum: 5aec1824db3575d63754de18c2629bcd820bc836d836f8a6346bcd9aa2ae4c397e090c43ea482ee765b704e018001015b5c84c5ded301a6a1144129c1a4c509b
   languageName: node
   linkType: hard
 
@@ -14875,6 +15000,23 @@ __metadata:
   bin:
     solcjs: solc.js
   checksum: a11de198bc5d481485a4a4803fb08a81a56dd9ffa7cdc62f8d6d5fc669f72e7cb4b22789004d54481353463421f6e6e3d1dffe7365b6d0ed5f37baee303266db
+  languageName: node
+  linkType: hard
+
+"solc@npm:0.8.26":
+  version: 0.8.26
+  resolution: "solc@npm:0.8.26"
+  dependencies:
+    command-exists: ^1.2.8
+    commander: ^8.1.0
+    follow-redirects: ^1.12.1
+    js-sha3: 0.8.0
+    memorystream: ^0.3.1
+    semver: ^5.5.0
+    tmp: 0.0.33
+  bin:
+    solcjs: solc.js
+  checksum: e3eaeac76e60676377b357af8f3919d4c8c6a74b74112b49279fe8c74a3dfa1de8afe4788689fc307453bde336edc8572988d2cf9e909f84d870420eb640400c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Fixed couple of minor bugs in the wampl-weth vault manager implementation. 1) Force rebalancing when limit ranges change. 2) Handling invalid oracle data, winding down to inf range. 3) Removing limit ranges completely instead of narrow/wide
* Added a new auto manager for the SPOT-USDC charm vault. (mostly similar to wampl-weth, but adjusts liquidity based on SPOT's deviation from FMV)