### PR TITLE
Spot pricer for automanager

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [20.x]
-        os: [ubuntu-latest]
+        os: [macos-latest]
 
     steps:
       - name: Setup Repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: true
       matrix:
         node-version: [20.x]
-        os: [ubuntu-latest]
+        os: [macos-latest]
 
     steps:
       - name: Setup Repo

--- a/spot-vaults/README.md
+++ b/spot-vaults/README.md
@@ -5,9 +5,10 @@ This repository is a collection of vault strategies leveraging the SPOT system.
 The official mainnet addresses are:
 
 - Bill Broker (SPOT-USDC): [0xA088Aef966CAD7fE0B38e28c2E07590127Ab4ccB](https://etherscan.io/address/0xA088Aef966CAD7fE0B38e28c2E07590127Ab4ccB)
-- SpotAppraiser: [0x965FBFebDA76d9AA11642C1d0074CdF02e546F3c](https://etherscan.io/address/0x965FBFebDA76d9AA11642C1d0074CdF02e546F3c)
 - WethWamplManager: [0x6785fa26191eb531c54fd093931f395c4b01b583](https://etherscan.io/address/0x6785fa26191eb531c54fd093931f395c4b01b583)
 - UsdcSpotManager: [0x780eB92040bf24cd9BF993505390e88E8ED59935](https://etherscan.io/address/0x780eB92040bf24cd9BF993505390e88E8ED59935)
+- SpotAppraiser: [0x965FBFebDA76d9AA11642C1d0074CdF02e546F3c](https://etherscan.io/address/0x965FBFebDA76d9AA11642C1d0074CdF02e546F3c) Used by the Bill Broker
+- SpotCDRPricer: [0x10B03340d27BC5470aa46Da007cD5BDE89201739](https://etherscan.io/address/0x10B03340d27BC5470aa46Da007cD5BDE89201739) Used by the Charm auto manager
 
 The official testnet addresses are:
 

--- a/spot-vaults/contracts/BillBroker.sol
+++ b/spot-vaults/contracts/BillBroker.sol
@@ -13,7 +13,7 @@ import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC
 import { IERC20MetadataUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 
 import { IPerpetualTranche } from "@ampleforthorg/spot-contracts/contracts/_interfaces/IPerpetualTranche.sol";
-import { IBillBrokerPricingStrategy } from "./_interfaces/IBillBrokerPricingStrategy.sol";
+import { ISpotPricingStrategy } from "./_interfaces/ISpotPricingStrategy.sol";
 import { ReserveState, BillBrokerFees, Line, Range } from "./_interfaces/BillBrokerTypes.sol";
 import { UnacceptableSwap, UnreliablePrice, UnexpectedDecimals, InvalidPerc, InvalidARBound, SlippageTooHigh, UnauthorizedCall, UnexpectedARDelta } from "./_interfaces/BillBrokerErrors.sol";
 
@@ -100,7 +100,7 @@ contract BillBroker is
     address public keeper;
 
     /// @notice The pricing strategy.
-    IBillBrokerPricingStrategy public pricingStrategy;
+    ISpotPricingStrategy public pricingStrategy;
 
     /// @notice All of the system fees.
     BillBrokerFees public fees;
@@ -141,7 +141,7 @@ contract BillBroker is
         string memory symbol,
         IERC20Upgradeable usd_,
         IPerpetualTranche perp_,
-        IBillBrokerPricingStrategy pricingStrategy_
+        ISpotPricingStrategy pricingStrategy_
     ) public initializer {
         // initialize dependencies
         __ERC20_init(name, symbol);
@@ -188,7 +188,7 @@ contract BillBroker is
     /// @notice Updates the reference to the pricing strategy.
     /// @param pricingStrategy_ The address of the new pricing strategy.
     function updatePricingStrategy(
-        IBillBrokerPricingStrategy pricingStrategy_
+        ISpotPricingStrategy pricingStrategy_
     ) public onlyOwner {
         if (pricingStrategy_.decimals() != DECIMALS) {
             revert UnexpectedDecimals();

--- a/spot-vaults/contracts/_interfaces/ISpotPricingStrategy.sol
+++ b/spot-vaults/contracts/_interfaces/ISpotPricingStrategy.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * @title IBillBrokerPricingStrategy
+ * @title ISpotPricingStrategy
  *
  * @notice Pricing strategy adapter for a BillBroker vault
  *         which accepts Perp and USDC tokens.
  *
  */
 // solhint-disable-next-line compiler-version
-interface IBillBrokerPricingStrategy {
+interface ISpotPricingStrategy {
     /// @return Number of decimals representing the prices returned.
     function decimals() external pure returns (uint8);
 

--- a/spot-vaults/contracts/_strategies/SpotAppraiser.sol
+++ b/spot-vaults/contracts/_strategies/SpotAppraiser.sol
@@ -50,6 +50,7 @@ contract SpotAppraiser is Ownable, ISpotPricingStrategy {
     uint256 private constant SPOT_DR_ONE = (10 ** SPOT_DR_DECIMALS);
     uint256 public constant CL_ORACLE_DECIMALS = 8;
     uint256 public constant CL_ORACLE_STALENESS_THRESHOLD_SEC = 3600 * 48; // 2 days
+    uint256 public constant USD_UPPER_BOUND = (101 * ONE) / 100; // 1.01$
     uint256 public constant USD_LOWER_BOUND = (99 * ONE) / 100; // 0.99$
     uint256 public constant AMPL_DUST_AMT = 25000 * (10 ** 9); // 25000 AMPL
 
@@ -130,10 +131,10 @@ contract SpotAppraiser is Ownable, ISpotPricingStrategy {
     /// @return v True if the price is valid and can be used by downstream consumers.
     function usdPrice() external view override returns (uint256, bool) {
         (uint256 p, bool v) = _getCLOracleData(USD_ORACLE, USD_ORACLE_DECIMALS);
-        // If the market price of the USD coin fallen too much below 1$,
+        // If the market price of the USD coin deviated too much from 1$,
         // it's an indication of some systemic issue with the USD token
         // and thus its price should be considered unreliable.
-        return (ONE, (v && p > USD_LOWER_BOUND));
+        return (ONE, (v && p < USD_UPPER_BOUND && p > USD_LOWER_BOUND));
     }
 
     /// @return p The price of the spot token in dollar coins.

--- a/spot-vaults/contracts/_strategies/SpotCDRPricer.sol
+++ b/spot-vaults/contracts/_strategies/SpotCDRPricer.sol
@@ -1,42 +1,30 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
 
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ITranche } from "@ampleforthorg/spot-contracts/contracts/_interfaces/buttonwood/ITranche.sol";
-import { IBondController } from "@ampleforthorg/spot-contracts/contracts/_interfaces/buttonwood/IBondController.sol";
 import { IPerpetualTranche } from "@ampleforthorg/spot-contracts/contracts/_interfaces/IPerpetualTranche.sol";
 import { IChainlinkOracle } from "../_interfaces/external/IChainlinkOracle.sol";
 import { IAmpleforthOracle } from "../_interfaces/external/IAmpleforthOracle.sol";
 import { ISpotPricingStrategy } from "../_interfaces/ISpotPricingStrategy.sol";
-import { InvalidSeniorCDRBound } from "../_interfaces/BillBrokerErrors.sol";
 
 /**
- * @title SpotAppraiser
+ * @title SpotCDRPricer
  *
- * @notice Pricing strategy adapter for a BillBroker vault which accepts
- *         SPOT (as the perp token) and dollar tokens like USDC.
+ * @notice Pricing strategy adapter for SPOT.
  *
- *         AMPL is the underlying token for SPOT.
- *         The market price of AMPL is mean reverting and eventually converges to its target.
- *         However, it can significantly deviate from the target in the near term.
+ *         SPOT is a perpetual claim on AMPL senior tranches.
+ *         We price spot based on the redeemable value of it's collateral at maturity.
+ *         NOTE: SPOT's internal `getTVL` prices the collateral this way.
  *
- *         SPOT is a perpetual claim on AMPL senior tranches. Insofar as SPOT is fully backed by
- *         healthy senior tranches, we can price spot reliably using the following strategy:
- *
- *         SPOT_PRICE = MULTIPLIER * AMPL_TARGET
- *         MULTIPLIER = spot.getTVL() / spot.totalSupply(), which is it's enrichment/debasement factor.
- *         To know more, read the spot documentation.
+ *         SPOT_PRICE = (spot.getTVL() / spot.totalSupply()) * AMPL_TARGET
  *
  *         We get the AMPL target price from Ampleforth's CPI oracle,
  *         which is also used by the protocol to adjust AMPL supply through rebasing.
  *
- *         And the MULTIPLIER is directly queried from the SPOT contract.
- *
  */
-contract SpotAppraiser is Ownable, ISpotPricingStrategy {
+contract SpotCDRPricer is ISpotPricingStrategy {
     //-------------------------------------------------------------------------
     // Libraries
     using Math for uint256;
@@ -46,12 +34,9 @@ contract SpotAppraiser is Ownable, ISpotPricingStrategy {
 
     uint256 private constant DECIMALS = 18;
     uint256 private constant ONE = (10 ** DECIMALS);
-    uint256 private constant SPOT_DR_DECIMALS = 8;
-    uint256 private constant SPOT_DR_ONE = (10 ** SPOT_DR_DECIMALS);
     uint256 public constant CL_ORACLE_DECIMALS = 8;
     uint256 public constant CL_ORACLE_STALENESS_THRESHOLD_SEC = 3600 * 48; // 2 days
     uint256 public constant USD_LOWER_BOUND = (99 * ONE) / 100; // 0.99$
-    uint256 public constant AMPL_DUST_AMT = 25000 * (10 ** 9); // 25000 AMPL
 
     /// @notice Address of the SPOT (perpetual tranche) ERC-20 token contract.
     IPerpetualTranche public immutable SPOT;
@@ -71,15 +56,6 @@ contract SpotAppraiser is Ownable, ISpotPricingStrategy {
     /// @notice Number of decimals representing the prices returned by the ampleforth oracle.
     uint256 public immutable AMPL_CPI_ORACLE_DECIMALS;
 
-    //-------------------------------------------------------------------------
-    // Storage
-
-    /// @notice The minimum "deviation ratio" of the SPOT outside which it's considered unhealthy.
-    uint256 public minSPOTDR;
-
-    /// @notice The minimum CDR of senior tranches backing SPOT outside which it's considered unhealthy.
-    uint256 public minSeniorCDR;
-
     //-----------------------------------------------------------------------------
     // Constructor
 
@@ -91,7 +67,7 @@ contract SpotAppraiser is Ownable, ISpotPricingStrategy {
         IPerpetualTranche spot,
         IChainlinkOracle usdOracle,
         IAmpleforthOracle cpiOracle
-    ) Ownable() {
+    ) {
         SPOT = spot;
         AMPL = IERC20(address(spot.underlying()));
 
@@ -100,27 +76,6 @@ contract SpotAppraiser is Ownable, ISpotPricingStrategy {
 
         AMPL_CPI_ORACLE = cpiOracle;
         AMPL_CPI_ORACLE_DECIMALS = cpiOracle.DECIMALS();
-
-        minSPOTDR = (ONE * 8) / 10; // 0.8
-        minSeniorCDR = (ONE * 11) / 10; // 110%
-    }
-
-    //--------------------------------------------------------------------------
-    // Owner only methods
-
-    /// @notice Controls the minimum `deviationRatio` ratio of SPOT below which SPOT is considered unhealthy.
-    /// @param minSPOTDR_ The minimum SPOT `deviationRatio`.
-    function updateMinSPOTDR(uint256 minSPOTDR_) external onlyOwner {
-        minSPOTDR = minSPOTDR_;
-    }
-
-    /// @notice Controls the minimum CDR of SPOT's senior tranche below which SPOT is considered unhealthy.
-    /// @param minSeniorCDR_ The minimum senior tranche CDR.
-    function updateMinPerpCollateralCDR(uint256 minSeniorCDR_) external onlyOwner {
-        if (minSeniorCDR_ < ONE) {
-            revert InvalidSeniorCDRBound();
-        }
-        minSeniorCDR = minSeniorCDR_;
     }
 
     //--------------------------------------------------------------------------
@@ -143,58 +98,12 @@ contract SpotAppraiser is Ownable, ISpotPricingStrategy {
         // we don't adjust the returned values.
         (uint256 targetPrice, bool targetPriceValid) = AMPL_CPI_ORACLE.getData();
         uint256 p = targetPrice.mulDiv(SPOT.getTVL(), SPOT.totalSupply());
-        bool v = (targetPriceValid && isSPOTHealthy());
-        return (p, v);
+        return (p, targetPriceValid);
     }
 
     /// @return Number of decimals representing a price of 1.0 USD.
     function decimals() external pure override returns (uint8) {
         return uint8(DECIMALS);
-    }
-
-    //-----------------------------------------------------------------------------
-    // Public methods
-
-    /// @return If the spot token is healthy.
-    function isSPOTHealthy() public returns (bool) {
-        // If the SPOT's `deviationRatio` is lower than the defined bound
-        // i.e) it doesn't have enough capital to cover future rollovers,
-        // we consider it unhealthy.
-        uint256 spotDR = SPOT.deviationRatio().mulDiv(ONE, SPOT_DR_ONE);
-        if (spotDR < minSPOTDR) {
-            return false;
-        }
-
-        // We compute the CDR of all the senior tranches backing perp.
-        // If any one of the seniors is mature or has a CDR below below the defined minimum,
-        // we consider it unhealthy.
-        // NOTE: Any CDR below 100%, means that the tranche is impaired
-        // and is roughly equivalent to holding AMPL.
-        uint8 reserveCount = uint8(SPOT.getReserveCount());
-        for (uint8 i = 1; i < reserveCount; i++) {
-            ITranche tranche = ITranche(address(SPOT.getReserveAt(i)));
-            IBondController bond = IBondController(tranche.bond());
-            if (bond.isMature()) {
-                return false;
-            }
-            uint256 seniorCDR = AMPL.balanceOf(address(bond)).mulDiv(
-                ONE,
-                tranche.totalSupply()
-            );
-            if (seniorCDR < minSeniorCDR) {
-                return false;
-            }
-        }
-
-        // If SPOT has ANY raw AMPL as collateral, we consider it unhealthy.
-        // NOTE: In practice some dust might exist or someone could grief this check
-        // by transferring some dust AMPL into the spot contract.
-        // We consider SPOT unhealthy if it has more than `AMPL_DUST_AMT` AMPL.
-        if (AMPL.balanceOf(address(SPOT)) > AMPL_DUST_AMT) {
-            return false;
-        }
-
-        return true;
     }
 
     //-----------------------------------------------------------------------------

--- a/spot-vaults/contracts/_strategies/SpotCDRPricer.sol
+++ b/spot-vaults/contracts/_strategies/SpotCDRPricer.sol
@@ -36,6 +36,7 @@ contract SpotCDRPricer is ISpotPricingStrategy {
     uint256 private constant ONE = (10 ** DECIMALS);
     uint256 public constant CL_ORACLE_DECIMALS = 8;
     uint256 public constant CL_ORACLE_STALENESS_THRESHOLD_SEC = 3600 * 48; // 2 days
+    uint256 public constant USD_LOWER_UPPER = (101 * ONE) / 100; // 1.01$
     uint256 public constant USD_LOWER_BOUND = (99 * ONE) / 100; // 0.99$
 
     /// @notice Address of the SPOT (perpetual tranche) ERC-20 token contract.
@@ -85,10 +86,10 @@ contract SpotCDRPricer is ISpotPricingStrategy {
     /// @return v True if the price is valid and can be used by downstream consumers.
     function usdPrice() external view override returns (uint256, bool) {
         (uint256 p, bool v) = _getCLOracleData(USD_ORACLE, USD_ORACLE_DECIMALS);
-        // If the market price of the USD coin fallen too much below 1$,
+        // If the market price of the USD coin deviated too much from 1$,
         // it's an indication of some systemic issue with the USD token
         // and thus its price should be considered unreliable.
-        return (ONE, (v && p > USD_LOWER_BOUND));
+        return (ONE, (v && p < USD_LOWER_UPPER && p > USD_LOWER_BOUND));
     }
 
     /// @return p The price of the spot token in dollar coins.

--- a/spot-vaults/contracts/_strategies/SpotCDRPricer.sol
+++ b/spot-vaults/contracts/_strategies/SpotCDRPricer.sol
@@ -36,7 +36,7 @@ contract SpotCDRPricer is ISpotPricingStrategy {
     uint256 private constant ONE = (10 ** DECIMALS);
     uint256 public constant CL_ORACLE_DECIMALS = 8;
     uint256 public constant CL_ORACLE_STALENESS_THRESHOLD_SEC = 3600 * 48; // 2 days
-    uint256 public constant USD_LOWER_UPPER = (101 * ONE) / 100; // 1.01$
+    uint256 public constant USD_UPPER_BOUND = (101 * ONE) / 100; // 1.01$
     uint256 public constant USD_LOWER_BOUND = (99 * ONE) / 100; // 0.99$
 
     /// @notice Address of the SPOT (perpetual tranche) ERC-20 token contract.
@@ -89,7 +89,7 @@ contract SpotCDRPricer is ISpotPricingStrategy {
         // If the market price of the USD coin deviated too much from 1$,
         // it's an indication of some systemic issue with the USD token
         // and thus its price should be considered unreliable.
-        return (ONE, (v && p < USD_LOWER_UPPER && p > USD_LOWER_BOUND));
+        return (ONE, (v && p < USD_UPPER_BOUND && p > USD_LOWER_BOUND));
     }
 
     /// @return p The price of the spot token in dollar coins.

--- a/spot-vaults/tasks/deploy.ts
+++ b/spot-vaults/tasks/deploy.ts
@@ -36,6 +36,33 @@ task("deploy:SpotAppraiser")
       await sleep(30);
       await hre.run("verify:contract", {
         address: spotAppraiser.target,
+        constructorArguments: [perp, usdOracle, cpiOracle],
+      });
+    } else {
+      console.log("Skipping verification");
+    }
+  });
+
+task("deploy:SpotCDRPricer")
+  .addParam("perp", "the address of the perp token", undefined, types.string, false)
+  .addParam("usdOracle", "the address of the usd oracle", undefined, types.string, false)
+  .addParam("cpiOracle", "the address of the usd oracle", undefined, types.string, false)
+  .addParam("verify", "flag to set false for local deployments", true, types.boolean)
+  .setAction(async function (args: TaskArguments, hre) {
+    const deployer = (await hre.ethers.getSigners())[0];
+    console.log("Signer", await deployer.getAddress());
+
+    const { perp, usdOracle, cpiOracle } = args;
+
+    const SpotCDRPricer = await hre.ethers.getContractFactory("SpotCDRPricer");
+    const spotCDRPricer = await SpotCDRPricer.deploy(perp, usdOracle, cpiOracle);
+    console.log("spotCDRPricer", spotCDRPricer.target);
+
+    if (args.verify) {
+      await sleep(30);
+      await hre.run("verify:contract", {
+        address: spotCDRPricer.target,
+        constructorArguments: [perp, usdOracle, cpiOracle],
       });
     } else {
       console.log("Skipping verification");

--- a/spot-vaults/tasks/info.ts
+++ b/spot-vaults/tasks/info.ts
@@ -31,21 +31,21 @@ task("info:BillBroker")
     const unitUsd = await billBroker.usdUnitAmt();
     const unitPerp = await billBroker.perpUnitAmt();
 
-    const spotAppraiser = await hre.ethers.getContractAt(
-      "SpotAppraiser",
+    const pricingStrategy = await hre.ethers.getContractAt(
+      "pricingStrategy",
       await billBroker.pricingStrategy.staticCall(),
     );
-    const appraiserDecimals = await spotAppraiser.decimals();
+    const pricingStrategyDecimals = await pricingStrategy.decimals();
     console.log("---------------------------------------------------------------");
-    console.log("SpotAppraiser:", spotAppraiser.target);
-    console.log("owner:", await spotAppraiser.owner());
-    const usdPriceCall = await spotAppraiser.usdPrice.staticCall();
-    console.log("usdPrice:", pp(usdPriceCall[0], appraiserDecimals));
+    console.log("pricingStrategy:", pricingStrategy.target);
+    console.log("owner:", await pricingStrategy.owner());
+    const usdPriceCall = await pricingStrategy.usdPrice.staticCall();
+    console.log("usdPrice:", pp(usdPriceCall[0], pricingStrategyDecimals));
     console.log("usdPriceValid:", usdPriceCall[1]);
-    const perpPriceCall = await spotAppraiser.perpPrice.staticCall();
-    console.log("perpPrice:", pp(perpPriceCall[0], appraiserDecimals));
+    const perpPriceCall = await pricingStrategy.perpPrice.staticCall();
+    console.log("perpPrice:", pp(perpPriceCall[0], pricingStrategyDecimals));
     console.log("perpPriceValid:", perpPriceCall[1]);
-    console.log("isSpotHealthy:", await spotAppraiser.isSPOTHealthy.staticCall());
+    console.log("isSpotHealthy:", await pricingStrategy.isSPOTHealthy.staticCall());
     console.log("---------------------------------------------------------------");
     console.log("BillBroker:", billBroker.target);
     console.log("owner:", await billBroker.owner());
@@ -197,7 +197,6 @@ task("info:UsdcSpotManager")
     console.log("---------------------------------------------------------------");
     console.log("UsdcSpotManager:", manager.target);
     console.log("owner:", await manager.owner());
-    console.log("spotAppraiser:", await manager.spotAppraiser());
 
     console.log("---------------------------------------------------------------");
     const spotPrice = await manager.getSpotUSDPrice();

--- a/spot-vaults/test/SpotAppraiser.ts
+++ b/spot-vaults/test/SpotAppraiser.ts
@@ -176,6 +176,22 @@ describe("SpotAppraiser", function () {
       });
     });
 
+    describe("when oracle price is above thresh", function () {
+      it("should return invalid", async function () {
+        const { strategy, usdPriceOrcle } = await loadFixture(setupContracts);
+        await usdPriceOrcle.mockMethod("latestRoundData()", [
+          0,
+          oracleAnsFP("1.02"),
+          0,
+          nowTS(),
+          0,
+        ]);
+        const p = await strategy.usdPrice();
+        expect(p[0]).to.eq(priceFP("1"));
+        expect(p[1]).to.eq(false);
+      });
+    });
+
     it("should return price", async function () {
       const { strategy } = await loadFixture(setupContracts);
       const p = await strategy.usdPrice();

--- a/spot-vaults/test/SpotCDRPricer.ts
+++ b/spot-vaults/test/SpotCDRPricer.ts
@@ -103,6 +103,22 @@ describe("SpotCDRPricer", function () {
       });
     });
 
+    describe("when oracle price is above thresh", function () {
+      it("should return invalid", async function () {
+        const { strategy, usdPriceOrcle } = await loadFixture(setupContracts);
+        await usdPriceOrcle.mockMethod("latestRoundData()", [
+          0,
+          oracleAnsFP("1.02"),
+          0,
+          nowTS(),
+          0,
+        ]);
+        const p = await strategy.usdPrice();
+        expect(p[0]).to.eq(priceFP("1"));
+        expect(p[1]).to.eq(false);
+      });
+    });
+
     it("should return price", async function () {
       const { strategy } = await loadFixture(setupContracts);
       const p = await strategy.usdPrice();

--- a/spot-vaults/test/SpotCDRPricer.ts
+++ b/spot-vaults/test/SpotCDRPricer.ts
@@ -1,0 +1,151 @@
+import { ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { expect } from "chai";
+import { oracleAnsFP, perpFP, priceFP, DMock } from "./helpers";
+
+const nowTS = () => parseInt(Date.now() / 1000);
+
+describe("SpotCDRPricer", function () {
+  async function setupContracts() {
+    const accounts = await ethers.getSigners();
+    const deployer = accounts[0];
+
+    const amplTargetOracle = new DMock("MedianOracle");
+    await amplTargetOracle.deploy();
+    await amplTargetOracle.mockMethod("getData()", [priceFP("1.15"), true]);
+    await amplTargetOracle.mockMethod("DECIMALS()", [18]);
+
+    const policy = new DMock("UFragmentsPolicy");
+    await policy.deploy();
+    await policy.mockMethod("cpiOracle()", [amplTargetOracle.target]);
+
+    const ampl = new DMock("UFragments");
+    await ampl.deploy();
+    await ampl.mockMethod("decimals()", [9]);
+    await ampl.mockMethod("monetaryPolicy()", [policy.target]);
+
+    const spot = new DMock("PerpetualTranche");
+    await spot.deploy();
+    await spot.mockMethod("underlying()", [ampl.target]);
+    await spot.mockMethod("getTVL()", [perpFP("1000000")]);
+    await spot.mockMethod("totalSupply()", [perpFP("1000000")]);
+
+    const usdPriceOrcle = new DMock("IChainlinkOracle");
+    await usdPriceOrcle.deploy();
+    await usdPriceOrcle.mockMethod("decimals()", [8]);
+    await usdPriceOrcle.mockMethod("latestRoundData()", [
+      0,
+      oracleAnsFP("1"),
+      0,
+      nowTS(),
+      0,
+    ]);
+
+    const SpotCDRPricer = await ethers.getContractFactory("SpotCDRPricer");
+    const strategy = await SpotCDRPricer.deploy(
+      spot.target,
+      usdPriceOrcle.target,
+      amplTargetOracle.target,
+    );
+    return {
+      deployer,
+      ampl,
+      spot,
+      usdPriceOrcle,
+      amplTargetOracle,
+      strategy,
+    };
+  }
+
+  describe("init", function () {
+    it("should initial params", async function () {
+      const { strategy, ampl, spot, usdPriceOrcle, amplTargetOracle } = await loadFixture(
+        setupContracts,
+      );
+      expect(await strategy.AMPL()).to.eq(ampl.target);
+      expect(await strategy.SPOT()).to.eq(spot.target);
+      expect(await strategy.USD_ORACLE()).to.eq(usdPriceOrcle.target);
+      expect(await strategy.AMPL_CPI_ORACLE()).to.eq(amplTargetOracle.target);
+      expect(await strategy.decimals()).to.eq(18);
+    });
+  });
+
+  describe("#usdPrice", function () {
+    describe("when data is stale", function () {
+      it("should return invalid", async function () {
+        const { strategy, usdPriceOrcle } = await loadFixture(setupContracts);
+        await usdPriceOrcle.mockMethod("latestRoundData()", [
+          0,
+          oracleAnsFP("1"),
+          0,
+          nowTS() - 50 * 3600,
+          0,
+        ]);
+        const p = await strategy.usdPrice();
+        expect(p[0]).to.eq(priceFP("1"));
+        expect(p[1]).to.eq(false);
+      });
+    });
+
+    describe("when oracle price is below thresh", function () {
+      it("should return invalid", async function () {
+        const { strategy, usdPriceOrcle } = await loadFixture(setupContracts);
+        await usdPriceOrcle.mockMethod("latestRoundData()", [
+          0,
+          oracleAnsFP("0.98"),
+          0,
+          nowTS(),
+          0,
+        ]);
+        const p = await strategy.usdPrice();
+        expect(p[0]).to.eq(priceFP("1"));
+        expect(p[1]).to.eq(false);
+      });
+    });
+
+    it("should return price", async function () {
+      const { strategy } = await loadFixture(setupContracts);
+      const p = await strategy.usdPrice();
+      expect(p[0]).to.eq(priceFP("1"));
+      expect(p[1]).to.eq(true);
+    });
+  });
+
+  describe("#perpPrice", function () {
+    describe("when AMPL target data is invalid", function () {
+      it("should return invalid", async function () {
+        const { strategy, amplTargetOracle } = await loadFixture(setupContracts);
+        await amplTargetOracle.mockMethod("getData()", [priceFP("1.2"), false]);
+        const p = await strategy.perpPrice.staticCall();
+        expect(p[0]).to.eq(priceFP("1.2"));
+        expect(p[1]).to.eq(false);
+      });
+    });
+
+    it("should return price", async function () {
+      const { strategy } = await loadFixture(setupContracts);
+      const p = await strategy.perpPrice.staticCall();
+      expect(p[0]).to.eq(priceFP("1.15"));
+      expect(p[1]).to.eq(true);
+    });
+
+    describe("when debasement/enrichment multiplier is not 1", function () {
+      it("should return price", async function () {
+        const { strategy, spot } = await loadFixture(setupContracts);
+        await spot.mockMethod("getTVL()", [perpFP("1500000")]);
+        await spot.mockMethod("totalSupply()", [perpFP("1000000")]);
+        const p = await strategy.perpPrice.staticCall();
+        expect(p[0]).to.eq(priceFP("1.725"));
+        expect(p[1]).to.eq(true);
+      });
+      it("should return price", async function () {
+        const { strategy, spot } = await loadFixture(setupContracts);
+        await spot.mockMethod("getTVL()", [perpFP("900000")]);
+        await spot.mockMethod("totalSupply()", [perpFP("1000000")]);
+        const p = await strategy.perpPrice.staticCall();
+        expect(p[0]).to.eq(priceFP("1.035"));
+        expect(p[1]).to.eq(true);
+      });
+    });
+  });
+});

--- a/spot-vaults/test/UsdcSpotManager.ts
+++ b/spot-vaults/test/UsdcSpotManager.ts
@@ -28,7 +28,7 @@ describe("UsdcSpotManager", function () {
     await mockPool.deploy();
     await mockVault.mockMethod("pool()", [mockPool.target]);
 
-    const mockAppraiser = new DMock("IBillBrokerPricingStrategy");
+    const mockAppraiser = new DMock("ISpotPricingStrategy");
     await mockAppraiser.deploy();
     await mockAppraiser.mockMethod("decimals()", [18]);
     await mockAppraiser.mockMethod("perpPrice()", [priceFP("1.2"), true]);
@@ -71,7 +71,7 @@ describe("UsdcSpotManager", function () {
 
     it("should set the appraiser address", async function () {
       const { manager, mockAppraiser } = await loadFixture(setupContracts);
-      expect(await manager.spotAppraiser()).to.eq(mockAppraiser.target);
+      expect(await manager.pricingStrategy()).to.eq(mockAppraiser.target);
     });
 
     it("should set the token refs", async function () {
@@ -102,18 +102,18 @@ describe("UsdcSpotManager", function () {
     });
   });
 
-  describe("#setSpotAppraiser", function () {
+  describe("#updatePricingStrategy", function () {
     it("should fail to when called by non-owner", async function () {
       const { manager, addr1 } = await loadFixture(setupContracts);
       await expect(
-        manager.connect(addr1).setSpotAppraiser(addr1.address),
+        manager.connect(addr1).updatePricingStrategy(addr1.address),
       ).to.be.revertedWith("Unauthorized caller");
     });
 
     it("should succeed when called by owner", async function () {
       const { manager, addr1 } = await loadFixture(setupContracts);
-      await manager.setSpotAppraiser(addr1.address);
-      expect(await manager.spotAppraiser()).to.eq(await addr1.getAddress());
+      await manager.updatePricingStrategy(addr1.address);
+      expect(await manager.pricingStrategy()).to.eq(await addr1.getAddress());
     });
   });
 


### PR DESCRIPTION
Added a new SPOT pricing strategy for the charm manager. 

The bill broker uses the spot appraiser which has stricter rules around DR and tranche CDRs. However, the AMM pool can use a much simpler pricing strategy.