### PR TITLE
Updated liquidity check condition based on system subscription ratio

### DIFF
--- a/spot-contracts/test/rollover-vault/RolloverVault.ts
+++ b/spot-contracts/test/rollover-vault/RolloverVault.ts
@@ -72,9 +72,9 @@ describe("RolloverVault", function () {
     });
 
     it("should set initial param values", async function () {
-      expect(await vault.minUnderlyingPerc()).to.eq(toPercFixedPtAmt("0.33333333"));
       expect(await vault.minDeploymentAmt()).to.eq("0");
-      expect(await vault.minUnderlyingBal()).to.eq("0");
+      expect(await vault.reservedUnderlyingBal()).to.eq("0");
+      expect(await vault.reservedSubscriptionPerc()).to.eq("0");
     });
 
     it("should initialize lists", async function () {
@@ -291,7 +291,7 @@ describe("RolloverVault", function () {
     });
   });
 
-  describe("#updateMinDeploymentAmt", function () {
+  describe("#updateReservedUnderlyingBal", function () {
     let tx: Transaction;
     beforeEach(async function () {
       await vault.connect(deployer).updateKeeper(await otherUser.getAddress());
@@ -299,7 +299,7 @@ describe("RolloverVault", function () {
 
     describe("when triggered by non-keeper", function () {
       it("should revert", async function () {
-        await expect(vault.connect(deployer).updateMinDeploymentAmt(0)).to.be.revertedWithCustomError(
+        await expect(vault.connect(deployer).updateReservedUnderlyingBal(0)).to.be.revertedWithCustomError(
           vault,
           "UnauthorizedCall",
         );
@@ -308,16 +308,16 @@ describe("RolloverVault", function () {
 
     describe("when triggered by keeper", function () {
       beforeEach(async function () {
-        tx = await vault.connect(otherUser).updateMinDeploymentAmt(toFixedPtAmt("1000"));
+        tx = await vault.connect(otherUser).updateReservedUnderlyingBal(toFixedPtAmt("1000"));
         await tx;
       });
       it("should update the min deployment amount", async function () {
-        expect(await vault.minDeploymentAmt()).to.eq(toFixedPtAmt("1000"));
+        expect(await vault.reservedUnderlyingBal()).to.eq(toFixedPtAmt("1000"));
       });
     });
   });
 
-  describe("#updateMinUnderlyingBal", function () {
+  describe("#updateReservedUnderlyingBal", function () {
     let tx: Transaction;
     beforeEach(async function () {
       await vault.connect(deployer).updateKeeper(await otherUser.getAddress());
@@ -325,7 +325,7 @@ describe("RolloverVault", function () {
 
     describe("when triggered by non-keeper", function () {
       it("should revert", async function () {
-        await expect(vault.connect(deployer).updateMinUnderlyingBal(0)).to.be.revertedWithCustomError(
+        await expect(vault.connect(deployer).updateReservedUnderlyingBal(0)).to.be.revertedWithCustomError(
           vault,
           "UnauthorizedCall",
         );
@@ -334,16 +334,16 @@ describe("RolloverVault", function () {
 
     describe("when triggered by keeper", function () {
       beforeEach(async function () {
-        tx = await vault.connect(otherUser).updateMinUnderlyingBal(toFixedPtAmt("1000"));
+        tx = await vault.connect(otherUser).updateReservedUnderlyingBal(toFixedPtAmt("1000"));
         await tx;
       });
       it("should update the min underlying balance", async function () {
-        expect(await vault.minUnderlyingBal()).to.eq(toFixedPtAmt("1000"));
+        expect(await vault.reservedUnderlyingBal()).to.eq(toFixedPtAmt("1000"));
       });
     });
   });
 
-  describe("#updateMinUnderlyingPerc", function () {
+  describe("#updateReservedSubscriptionPerc", function () {
     let tx: Transaction;
     beforeEach(async function () {
       await vault.connect(deployer).updateKeeper(await otherUser.getAddress());
@@ -351,7 +351,7 @@ describe("RolloverVault", function () {
 
     describe("when triggered by non-keeper", function () {
       it("should revert", async function () {
-        await expect(vault.connect(deployer).updateMinUnderlyingPerc(0)).to.be.revertedWithCustomError(
+        await expect(vault.connect(deployer).updateReservedSubscriptionPerc(0)).to.be.revertedWithCustomError(
           vault,
           "UnauthorizedCall",
         );
@@ -360,11 +360,11 @@ describe("RolloverVault", function () {
 
     describe("when triggered by keeper", function () {
       beforeEach(async function () {
-        tx = await vault.connect(otherUser).updateMinUnderlyingPerc(toPercFixedPtAmt("0.1"));
+        tx = await vault.connect(otherUser).updateReservedSubscriptionPerc(toPercFixedPtAmt("0.1"));
         await tx;
       });
       it("should update the min underlying balance", async function () {
-        expect(await vault.minUnderlyingPerc()).to.eq(toPercFixedPtAmt("0.1"));
+        expect(await vault.reservedSubscriptionPerc()).to.eq(toPercFixedPtAmt("0.1"));
       });
     });
   });

--- a/spot-contracts/test/rollover-vault/RolloverVault_deploy.ts
+++ b/spot-contracts/test/rollover-vault/RolloverVault_deploy.ts
@@ -110,13 +110,13 @@ describe("RolloverVault", function () {
   describe("#deploy", function () {
     describe("when usable balance is zero", function () {
       it("should revert", async function () {
-        await expect(vault.deploy()).to.be.revertedWithCustomError(vault, "InsufficientLiquidity");
+        await expect(vault.deploy()).to.be.revertedWithCustomError(vault, "InsufficientDeployment");
       });
     });
 
-    describe("when minUnderlyingBal is not set", function () {
+    describe("when reservedUnderlyingBal is not set", function () {
       beforeEach(async function () {
-        await vault.updateMinUnderlyingBal(toFixedPtAmt("0"));
+        await vault.updateReservedUnderlyingBal(toFixedPtAmt("0"));
       });
 
       describe("when usable balance is lower than the min deployment", function () {
@@ -140,18 +140,18 @@ describe("RolloverVault", function () {
       });
     });
 
-    describe("when minUnderlyingBal is set", function () {
+    describe("when reservedUnderlyingBal is set", function () {
       beforeEach(async function () {
-        await vault.updateMinUnderlyingBal(toFixedPtAmt("25"));
+        await vault.updateReservedUnderlyingBal(toFixedPtAmt("25"));
       });
 
-      describe("when usable balance is lower than the minUnderlyingBal", function () {
+      describe("when usable balance is lower than the reservedUnderlyingBal", function () {
         beforeEach(async function () {
           await collateralToken.transfer(vault.address, toFixedPtAmt("20"));
           await vault.updateMinDeploymentAmt(toFixedPtAmt("1"));
         });
         it("should revert", async function () {
-          await expect(vault.deploy()).to.be.revertedWithCustomError(vault, "InsufficientLiquidity");
+          await expect(vault.deploy()).to.be.revertedWithCustomError(vault, "InsufficientDeployment");
         });
       });
 

--- a/spot-contracts/test/rollover-vault/RolloverVault_swap.ts
+++ b/spot-contracts/test/rollover-vault/RolloverVault_swap.ts
@@ -303,8 +303,8 @@ describe("RolloverVault", function () {
 
     describe("when absolute liquidity is too low", function () {
       beforeEach(async function () {
-        await vault.updateMinUnderlyingBal(toFixedPtAmt("1000"));
-        await vault.updateMinUnderlyingPerc(0);
+        await vault.updateReservedUnderlyingBal(toFixedPtAmt("1000"));
+        await vault.updateReservedSubscriptionPerc(0);
       });
       it("should be reverted", async function () {
         await expect(vault.swapUnderlyingForPerps(toFixedPtAmt("50"))).to.be.revertedWithCustomError(
@@ -317,15 +317,15 @@ describe("RolloverVault", function () {
 
     describe("when percentage of liquidity is too low", function () {
       beforeEach(async function () {
-        await vault.updateMinUnderlyingBal(0);
-        await vault.updateMinUnderlyingPerc(toPercFixedPtAmt("0.40"));
+        await vault.updateReservedUnderlyingBal(0);
+        await vault.updateReservedSubscriptionPerc(toPercFixedPtAmt("0.25"));
       });
       it("should be reverted", async function () {
         await expect(vault.swapUnderlyingForPerps(toFixedPtAmt("100"))).to.be.revertedWithCustomError(
           vault,
           "InsufficientLiquidity",
         );
-        await expect(vault.swapUnderlyingForPerps(toFixedPtAmt("99"))).not.to.be.reverted;
+        await expect(vault.swapUnderlyingForPerps(toFixedPtAmt("50"))).not.to.be.reverted;
       });
     });
 


### PR DESCRIPTION
1) Vault's min liquidity constraints are enforced universally before rollover and after swaps
2) The limiting percentage parameter is a percentage of vault's neutral TVL