### PR TITLE
Bill broker fee curve change

### DIFF
--- a/spot-vaults/contracts/BillBroker.sol
+++ b/spot-vaults/contracts/BillBroker.sol
@@ -17,7 +17,7 @@ import { IPerpPricer } from "./_interfaces/IPerpPricer.sol";
 import { ReserveState, BillBrokerFees } from "./_interfaces/types/BillBrokerTypes.sol";
 import { Line, Range } from "./_interfaces/types/CommonTypes.sol";
 import { UnacceptableSwap, UnreliablePrice, UnexpectedDecimals, InvalidPerc, SlippageTooHigh, UnauthorizedCall } from "./_interfaces/errors/CommonErrors.sol";
-import { InvalidARBound, UnexpectedARDelta } from "./_interfaces/errors/BillBrokerErrors.sol";
+import { InvalidARBound } from "./_interfaces/errors/BillBrokerErrors.sol";
 
 /**
  *  @title BillBroker
@@ -72,16 +72,20 @@ contract BillBroker is
 
     // Math
     using MathUpgradeable for uint256;
-    using LineHelpers for Line;
     using MathHelpers for int256;
+    using LineHelpers for Line;
 
     //-------------------------------------------------------------------------
     // Constants & Immutables
 
     uint256 public constant DECIMALS = 18;
     uint256 public constant ONE = (10 ** DECIMALS);
+    uint256 public constant TWO = ONE * 2;
     uint256 private constant INITIAL_RATE = 1000000;
     uint256 public constant MINIMUM_LIQUIDITY = 10 ** 22;
+    uint256 public constant MAX_FEE_FACTOR = TWO; // 2 or 100%
+    uint256 public constant MIN_FEE_FACTOR = ((ONE * 4) / 5); // 0.8 or -20%
+    uint256 public constant MAX_ASSET_RATIO = uint256(type(int256).max);
 
     //-------------------------------------------------------------------------
     // Storage
@@ -113,7 +117,7 @@ contract BillBroker is
     Range public arHardBound;
 
     /// @notice The asset ratio bounds outside which swapping is still functional but,
-    ///         the swap fees transition from a flat percentage fee to a linear function.
+    ///         the swap fees transition from a constant fee to a linear function.
     Range public arSoftBound;
 
     //--------------------------------------------------------------------------
@@ -189,17 +193,23 @@ contract BillBroker is
             BillBrokerFees({
                 mintFeePerc: 0,
                 burnFeePerc: 0,
-                perpToUSDSwapFeePercs: Range({ lower: ONE, upper: ONE }),
-                usdToPerpSwapFeePercs: Range({ lower: ONE, upper: ONE }),
+                perpToUSDSwapFeeFactors: Range({
+                    lower: MAX_FEE_FACTOR,
+                    upper: MAX_FEE_FACTOR
+                }),
+                usdToPerpSwapFeeFactors: Range({
+                    lower: MAX_FEE_FACTOR,
+                    upper: MAX_FEE_FACTOR
+                }),
                 protocolSwapSharePerc: 0
             })
         );
 
         updateARBounds(
             // Soft bound
-            Range({ lower: 0, upper: type(uint256).max }),
+            Range({ lower: 0, upper: MAX_ASSET_RATIO }),
             // Hard bound
-            Range({ lower: 0, upper: type(uint256).max })
+            Range({ lower: 0, upper: MAX_ASSET_RATIO })
         );
     }
 
@@ -227,8 +237,10 @@ contract BillBroker is
         if (
             fees_.mintFeePerc > ONE ||
             fees_.burnFeePerc > ONE ||
-            fees_.perpToUSDSwapFeePercs.lower > fees_.perpToUSDSwapFeePercs.upper ||
-            fees_.usdToPerpSwapFeePercs.lower > fees_.usdToPerpSwapFeePercs.upper ||
+            fees_.perpToUSDSwapFeeFactors.lower > fees_.perpToUSDSwapFeeFactors.upper ||
+            fees_.perpToUSDSwapFeeFactors.lower < ONE ||
+            fees_.usdToPerpSwapFeeFactors.lower > fees_.usdToPerpSwapFeeFactors.upper ||
+            fees_.usdToPerpSwapFeeFactors.lower < ONE ||
             fees_.protocolSwapSharePerc > ONE
         ) {
             revert InvalidPerc();
@@ -424,7 +436,7 @@ contract BillBroker is
         // compute perp amount out
         ReserveState memory s = reserveState();
         uint256 protocolFeePerpAmt;
-        (perpAmtOut, , protocolFeePerpAmt) = computeUSDToPerpSwapAmt(usdAmtIn, s);
+        (perpAmtOut, protocolFeePerpAmt) = computeUSDToPerpSwapAmt(usdAmtIn, s);
         if (usdAmtIn <= 0 || perpAmtOut <= 0) {
             revert UnacceptableSwap();
         }
@@ -458,7 +470,7 @@ contract BillBroker is
         // Compute swap amount
         ReserveState memory s = reserveState();
         uint256 protocolFeeUsdAmt;
-        (usdAmtOut, , protocolFeeUsdAmt) = computePerpToUSDSwapAmt(perpAmtIn, s);
+        (usdAmtOut, protocolFeeUsdAmt) = computePerpToUSDSwapAmt(perpAmtIn, s);
         if (perpAmtIn <= 0 || usdAmtOut <= 0) {
             revert UnacceptableSwap();
         }
@@ -507,7 +519,7 @@ contract BillBroker is
     function computePerpToUSDSwapAmt(
         uint256 perpAmtIn
     ) public returns (uint256 usdAmtOut) {
-        (usdAmtOut, , ) = computePerpToUSDSwapAmt(perpAmtIn, reserveState());
+        (usdAmtOut, ) = computePerpToUSDSwapAmt(perpAmtIn, reserveState());
     }
 
     /// @notice Computes the amount of perp tokens swapped out,
@@ -517,7 +529,7 @@ contract BillBroker is
     function computeUSDToPerpSwapAmt(
         uint256 usdAmtIn
     ) public returns (uint256 perpAmtOut) {
-        (perpAmtOut, , ) = computeUSDToPerpSwapAmt(usdAmtIn, reserveState());
+        (perpAmtOut, ) = computeUSDToPerpSwapAmt(usdAmtIn, reserveState());
     }
 
     /// @return s The reserve usd and perp token balances and prices.
@@ -633,22 +645,36 @@ contract BillBroker is
     function computeMintAmtWithUSD(
         uint256 usdAmtIn,
         ReserveState memory s
-    ) public view returns (uint256) {
+    ) public view returns (uint256 mintAmt) {
         if (usdAmtIn <= 0) {
             return 0;
         }
 
         // We compute equal value of perp tokens going out.
+        uint256 totalSupply_ = totalSupply();
         uint256 valueIn = s.usdPrice.mulDiv(usdAmtIn, usdUnitAmt);
         uint256 totalReserveVal = (s.usdPrice.mulDiv(s.usdBalance, usdUnitAmt) +
             s.perpPrice.mulDiv(s.perpBalance, perpUnitAmt));
-        return
-            (totalReserveVal > 0)
-                ? valueIn.mulDiv(totalSupply(), totalReserveVal).mulDiv(
-                    ONE - fees.mintFeePerc,
-                    ONE
-                )
-                : 0;
+        if (totalReserveVal == 0 || totalSupply_ == 0) {
+            return 0;
+        }
+
+        // Compute mint amount.
+        mintAmt = valueIn.mulDiv(totalSupply_, totalReserveVal);
+
+        // Apply a combination of swap and mint fees.
+        uint256 percOfAmtInSwapped = ONE.mulDiv(
+            usdAmtIn - mintAmt.mulDiv(s.usdBalance, totalSupply_),
+            usdAmtIn
+        );
+        uint256 feeFactor = computeUSDToPerpSwapFeeFactor(
+            assetRatio(s),
+            assetRatio(_updatedReserveState(s, s.usdBalance + usdAmtIn, s.perpBalance))
+        );
+        mintAmt =
+            mintAmt.mulDiv(percOfAmtInSwapped, ONE).mulDiv(TWO - feeFactor, ONE) +
+            mintAmt.mulDiv(ONE - percOfAmtInSwapped, ONE);
+        mintAmt = mintAmt.mulDiv(ONE - fees.mintFeePerc, ONE);
     }
 
     /// @notice Computes the amount of LP tokens minted,
@@ -659,22 +685,38 @@ contract BillBroker is
     function computeMintAmtWithPerp(
         uint256 perpAmtIn,
         ReserveState memory s
-    ) public view returns (uint256) {
+    ) public view returns (uint256 mintAmt) {
         if (perpAmtIn <= 0) {
             return 0;
         }
 
         // We compute equal value of perp tokens coming in.
+        uint256 totalSupply_ = totalSupply();
         uint256 valueIn = s.perpPrice.mulDiv(perpAmtIn, perpUnitAmt);
         uint256 totalReserveVal = (s.usdPrice.mulDiv(s.usdBalance, usdUnitAmt) +
             s.perpPrice.mulDiv(s.perpBalance, perpUnitAmt));
-        return
-            (totalReserveVal > 0)
-                ? valueIn.mulDiv(totalSupply(), totalReserveVal).mulDiv(
-                    ONE - fees.mintFeePerc,
-                    ONE
-                )
-                : 0;
+        if (totalReserveVal == 0 || totalSupply_ == 0) {
+            return 0;
+        }
+
+        // Compute mint amount.
+        mintAmt = (totalReserveVal > 0)
+            ? valueIn.mulDiv(totalSupply_, totalReserveVal)
+            : 0;
+
+        // Apply a combination of swap and mint fees.
+        uint256 percOfAmtInSwapped = ONE.mulDiv(
+            perpAmtIn - mintAmt.mulDiv(s.perpBalance, totalSupply_),
+            perpAmtIn
+        );
+        uint256 feeFactor = computePerpToUSDSwapFeeFactor(
+            assetRatio(s),
+            assetRatio(_updatedReserveState(s, s.usdBalance, s.perpBalance + perpAmtIn))
+        );
+        mintAmt =
+            mintAmt.mulDiv(percOfAmtInSwapped, ONE).mulDiv(TWO - feeFactor, ONE) +
+            mintAmt.mulDiv(ONE - percOfAmtInSwapped, ONE);
+        mintAmt = mintAmt.mulDiv(ONE - fees.mintFeePerc, ONE);
     }
 
     /// @notice Computes the amount of usd and perp tokens redeemed,
@@ -706,24 +748,19 @@ contract BillBroker is
     /// @param s The current reserve state.
     /// @dev Quoted usd token amount out includes the fees withheld.
     /// @return usdAmtOut The amount of usd tokens swapped out.
-    /// @return lpFeeUsdAmt The amount of usd tokens charged as swap fees by LPs.
     /// @return protocolFeeUsdAmt The amount of usd tokens charged as protocol fees.
     function computePerpToUSDSwapAmt(
         uint256 perpAmtIn,
         ReserveState memory s
-    )
-        public
-        view
-        returns (uint256 usdAmtOut, uint256 lpFeeUsdAmt, uint256 protocolFeeUsdAmt)
-    {
+    ) public view returns (uint256 usdAmtOut, uint256 protocolFeeUsdAmt) {
         // We compute equal value tokens to swap out.
         usdAmtOut = perpAmtIn.mulDiv(s.perpPrice, s.usdPrice).mulDiv(
             usdUnitAmt,
             perpUnitAmt
         );
 
-        // We compute the total fee percentage, lp fees and protocol fees
-        uint256 totalFeePerc = computePerpToUSDSwapFeePerc(
+        // We compute the fee factor
+        uint256 feeFactor = computePerpToUSDSwapFeeFactor(
             assetRatio(s),
             assetRatio(
                 _updatedReserveState(
@@ -733,13 +770,12 @@ contract BillBroker is
                 )
             )
         );
-        if (totalFeePerc >= ONE) {
-            return (0, 0, 0);
+        if (feeFactor >= ONE) {
+            protocolFeeUsdAmt = usdAmtOut
+                .mulDiv(feeFactor - ONE, ONE, MathUpgradeable.Rounding.Up)
+                .mulDiv(fees.protocolSwapSharePerc, ONE, MathUpgradeable.Rounding.Up);
         }
-        uint256 totalFeeUsdAmt = usdAmtOut.mulDiv(totalFeePerc, ONE);
-        usdAmtOut -= totalFeeUsdAmt;
-        protocolFeeUsdAmt = totalFeeUsdAmt.mulDiv(fees.protocolSwapSharePerc, ONE);
-        lpFeeUsdAmt = totalFeeUsdAmt - protocolFeeUsdAmt;
+        usdAmtOut = usdAmtOut.mulDiv(TWO - feeFactor, ONE);
     }
 
     /// @notice Computes the amount of perp tokens swapped out,
@@ -748,24 +784,19 @@ contract BillBroker is
     /// @param s The current reserve state.
     /// @dev Quoted perp token amount out includes the fees withheld.
     /// @return perpAmtOut The amount of perp tokens swapped out.
-    /// @return lpFeePerpAmt The amount of perp tokens charged as swap fees by LPs.
     /// @return protocolFeePerpAmt The amount of perp tokens charged as protocol fees.
     function computeUSDToPerpSwapAmt(
         uint256 usdAmtIn,
         ReserveState memory s
-    )
-        public
-        view
-        returns (uint256 perpAmtOut, uint256 lpFeePerpAmt, uint256 protocolFeePerpAmt)
-    {
+    ) public view returns (uint256 perpAmtOut, uint256 protocolFeePerpAmt) {
         // We compute equal value tokens to swap out.
         perpAmtOut = usdAmtIn.mulDiv(s.usdPrice, s.perpPrice).mulDiv(
             perpUnitAmt,
             usdUnitAmt
         );
 
-        // We compute the total fee percentage, lp fees and protocol fees
-        uint256 totalFeePerc = computeUSDToPerpSwapFeePerc(
+        // We compute the fee factor
+        uint256 feeFactor = computeUSDToPerpSwapFeeFactor(
             assetRatio(s),
             assetRatio(
                 _updatedReserveState(
@@ -775,122 +806,90 @@ contract BillBroker is
                 )
             )
         );
-        if (totalFeePerc >= ONE) {
-            return (0, 0, 0);
+        if (feeFactor >= ONE) {
+            protocolFeePerpAmt = perpAmtOut
+                .mulDiv(feeFactor - ONE, ONE, MathUpgradeable.Rounding.Up)
+                .mulDiv(fees.protocolSwapSharePerc, ONE, MathUpgradeable.Rounding.Up);
         }
-        uint256 totalFeePerpAmt = perpAmtOut.mulDiv(totalFeePerc, ONE);
-        perpAmtOut -= totalFeePerpAmt;
-        protocolFeePerpAmt = totalFeePerpAmt.mulDiv(fees.protocolSwapSharePerc, ONE);
-        lpFeePerpAmt = totalFeePerpAmt - protocolFeePerpAmt;
+        perpAmtOut = perpAmtOut.mulDiv(TWO - feeFactor, ONE);
     }
 
-    /// @notice Computes the swap fee percentage when swapping from perp to usd tokens.
+    /// @notice Computes the swap fee factor when swapping from perp to usd tokens.
     /// @dev Swapping from perp to usd tokens, leaves the system with more perp and fewer usd tokens
     ///      thereby decreasing the system's `assetRatio`. Thus arPost < arPre.
     /// @param arPre The asset ratio of the system before swapping.
     /// @param arPost The asset ratio of the system after swapping.
-    /// @return The fee percentage.
-    function computePerpToUSDSwapFeePerc(
+    /// @return The fee factor.
+    function computePerpToUSDSwapFeeFactor(
         uint256 arPre,
         uint256 arPost
     ) public view returns (uint256) {
-        if (arPost > arPre) {
-            revert UnexpectedARDelta();
+        // When the ar decreases below the lower bound swaps are halted.
+        if (arPost < arHardBound.lower) {
+            return MAX_FEE_FACTOR;
         }
 
-        // When the ar decreases below the lower bound,
-        // swaps are effectively halted by setting fees to 100%.
-        if (arPost < arHardBound.lower) {
-            return ONE;
-        }
-        // When the ar is between the soft and hard bound, a linear function is applied.
-        // When the ar is above the soft bound, a flat percentage fee is applied.
-        //
-        //   fee
-        //    ^
-        //    |
-        // fh |    \          |
-        //    |     \         |
-        //    |      \        |
-        //    |       \       |
-        //    |        \      |
-        //    |         \     |
-        // fl |          \__________
-        //    |               |
-        //    |               |
-        //    |               |
-        //    +---------------------------> ar
-        //       arHL  arSL  1.0
-        //
-        Range memory swapFeePercs = fees.perpToUSDSwapFeePercs;
+        Range memory f1 = fees.perpToUSDSwapFeeFactors;
+        Range memory f2 = fees.usdToPerpSwapFeeFactors;
         return
-            _computeFeePerc(
-                Line({
-                    x1: arHardBound.lower,
-                    y1: swapFeePercs.upper,
-                    x2: arSoftBound.lower,
-                    y2: swapFeePercs.lower
-                }),
-                Line({ x1: 0, y1: swapFeePercs.lower, x2: ONE, y2: swapFeePercs.lower }),
-                arPost,
-                arPre,
-                arSoftBound.lower
-            );
+            LineHelpers
+                .computePiecewiseAvgY(
+                    Line({
+                        x1: arHardBound.lower,
+                        y1: f1.upper,
+                        x2: arSoftBound.lower,
+                        y2: f1.lower
+                    }),
+                    Line({ x1: 0, y1: f1.lower, x2: ONE, y2: f1.lower }),
+                    Line({
+                        x1: arSoftBound.upper,
+                        y1: f1.lower,
+                        x2: arHardBound.upper,
+                        y2: (f1.lower + f2.lower - f2.upper)
+                    }),
+                    arSoftBound,
+                    Range({ lower: arPost, upper: arPre })
+                )
+                .clip(MIN_FEE_FACTOR, MAX_FEE_FACTOR);
     }
 
-    /// @notice Computes the swap fee percentage when swapping from usd to perp tokens.
+    /// @notice Computes the swap fee factor when swapping from usd to perp tokens.
     /// @dev Swapping from usd to perp tokens, leaves the system with more usd and fewer perp tokens
     ///      thereby increasing the system's `assetRatio`. Thus arPost > arPre.
     /// @param arPre The asset ratio of the system before swapping.
     /// @param arPost The asset ratio of the system after swapping.
-    /// @return The fee percentage.
-    function computeUSDToPerpSwapFeePerc(
+    /// @return The fee factor.
+    function computeUSDToPerpSwapFeeFactor(
         uint256 arPre,
         uint256 arPost
     ) public view returns (uint256) {
-        if (arPost < arPre) {
-            revert UnexpectedARDelta();
-        }
-
-        // When the ar increases above the hard bound,
-        // swaps are effectively halted by setting fees to 100%.
+        // When the ar increases above the hard bound, swaps are halted.
         if (arPost > arHardBound.upper) {
-            return ONE;
+            return MAX_FEE_FACTOR;
         }
 
-        // When the ar is between the soft and hard bound, a linear function is applied.
-        // When the ar is below the soft bound, a flat percentage fee is applied.
-        //
-        //   fee
-        //    ^
-        //    |
-        // fh |         |           /
-        //    |         |          /
-        //    |         |         /
-        //    |         |        /
-        //    |         |       /
-        //    |         |      /
-        // fl |     __________/
-        //    |         |
-        //    |         |
-        //    |         |
-        //    +---------------------------> ar
-        //              1.0  arSU   arHU
-        //
-        Range memory swapFeePercs = fees.usdToPerpSwapFeePercs;
+        Range memory f1 = fees.usdToPerpSwapFeeFactors;
+        Range memory f2 = fees.perpToUSDSwapFeeFactors;
         return
-            _computeFeePerc(
-                Line({ x1: 0, y1: swapFeePercs.lower, x2: ONE, y2: swapFeePercs.lower }),
-                Line({
-                    x1: arSoftBound.upper,
-                    y1: swapFeePercs.lower,
-                    x2: arHardBound.upper,
-                    y2: swapFeePercs.upper
-                }),
-                arPre,
-                arPost,
-                arSoftBound.upper
-            );
+            LineHelpers
+                .computePiecewiseAvgY(
+                    Line({
+                        x1: arSoftBound.lower,
+                        y1: f1.lower,
+                        x2: arHardBound.lower,
+                        y2: (f1.lower + f2.lower - f2.upper)
+                    }),
+                    Line({ x1: 0, y1: f1.lower, x2: ONE, y2: f1.lower }),
+                    Line({
+                        x1: arSoftBound.upper,
+                        y1: f1.lower,
+                        x2: arHardBound.upper,
+                        y2: f1.upper
+                    }),
+                    arSoftBound,
+                    Range({ lower: arPre, upper: arPost })
+                )
+                .clip(MIN_FEE_FACTOR, MAX_FEE_FACTOR);
     }
 
     /// @param s The system reserve state.
@@ -904,7 +903,7 @@ contract BillBroker is
                         s.perpBalance.mulDiv(s.perpPrice, perpUnitAmt)
                     )
                 )
-                : type(uint256).max;
+                : MAX_ASSET_RATIO;
     }
 
     /// @notice The address which holds any revenue extracted by protocol.
@@ -929,24 +928,5 @@ contract BillBroker is
                 usdPrice: s.usdPrice,
                 perpPrice: s.perpPrice
             });
-    }
-
-    /// @dev The function assumes the fee curve is defined as a pair-wise linear function which merge at the cutoff point.
-    ///      The swap fee is computed as avg height of the fee curve between {arL,arU}.
-    function _computeFeePerc(
-        Line memory fn1,
-        Line memory fn2,
-        uint256 arL,
-        uint256 arU,
-        uint256 cutoff
-    ) private pure returns (uint256 feePerc) {
-        if (arU <= cutoff) {
-            feePerc = fn1.avgY(arL, arU).clip(0, ONE);
-        } else if (arL >= cutoff) {
-            feePerc = fn2.avgY(arL, arU).clip(0, ONE);
-        } else {
-            feePerc += fn1.avgY(arL, cutoff).clip(0, ONE).mulDiv(cutoff - arL, arU - arL);
-            feePerc += fn2.avgY(cutoff, arU).clip(0, ONE).mulDiv(arU - cutoff, arU - arL);
-        }
     }
 }

--- a/spot-vaults/contracts/_interfaces/errors/CommonErrors.sol
+++ b/spot-vaults/contracts/_interfaces/errors/CommonErrors.sol
@@ -18,3 +18,9 @@ error UnacceptableSwap();
 
 /// @notice Expected usable external price.
 error UnreliablePrice();
+
+/// @notice Range upper is larger than lower
+error InvalidRange();
+
+/// @notice Expected range delta to be smaller.
+error UnexpectedRangeDelta();

--- a/spot-vaults/contracts/_interfaces/types/BillBrokerTypes.sol
+++ b/spot-vaults/contracts/_interfaces/types/BillBrokerTypes.sol
@@ -9,10 +9,11 @@ struct BillBrokerFees {
     uint256 mintFeePerc;
     /// @notice The percentage fee charged for burning BillBroker LP tokens.
     uint256 burnFeePerc;
-    /// @notice Range of fee percentages for swapping from perp tokens to USD.
-    Range perpToUSDSwapFeePercs;
-    /// @notice Range of fee percentages for swapping from USD to perp tokens.
-    Range usdToPerpSwapFeePercs;
+    /// @notice Range of fee factors for swapping from perp tokens to USD.
+    /// @dev Factor of 1.02 implies a +2% fees, and 0.98 implies a -2% fees.
+    Range perpToUSDSwapFeeFactors;
+    /// @notice Range of fee factors for swapping from USD to perp tokens.
+    Range usdToPerpSwapFeeFactors;
     /// @notice The percentage of the swap fees that goes to the protocol.
     uint256 protocolSwapSharePerc;
 }

--- a/spot-vaults/contracts/_test/LineHelpersTester.sol
+++ b/spot-vaults/contracts/_test/LineHelpersTester.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.24;
+
+import { LineHelpers } from "../_utils/LineHelpers.sol";
+import { Line, Range } from "../_interfaces/types/CommonTypes.sol";
+
+contract LineHelpersTester {
+    using LineHelpers for Line;
+
+    function testComputeY(Line memory fn, uint256 x) public pure returns (int256) {
+        return fn.computeY(x);
+    }
+
+    function testAvgY(
+        Line memory fn,
+        uint256 xL,
+        uint256 xU
+    ) public pure returns (int256) {
+        return fn.avgY(xL, xU);
+    }
+
+    function testComputePiecewiseAvgY(
+        Line memory fn1,
+        Line memory fn2,
+        Line memory fn3,
+        Range memory xBreakPt,
+        Range memory xRange
+    ) public pure returns (int256) {
+        return LineHelpers.computePiecewiseAvgY(fn1, fn2, fn3, xBreakPt, xRange);
+    }
+}

--- a/spot-vaults/contracts/_utils/LineHelpers.sol
+++ b/spot-vaults/contracts/_utils/LineHelpers.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.24;
 
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-import { Line } from "../_interfaces/types/CommonTypes.sol";
+import { MathHelpers } from "./MathHelpers.sol";
+import { Line, Range } from "../_interfaces/types/CommonTypes.sol";
+import { InvalidRange, UnexpectedRangeDelta } from "../_interfaces/errors/CommonErrors.sol";
 
 /**
  *  @title LineHelpers
@@ -11,24 +14,10 @@ import { Line } from "../_interfaces/types/CommonTypes.sol";
  *
  */
 library LineHelpers {
+    using Math for uint256;
+    using MathHelpers for uint256;
     using SafeCast for uint256;
-
-    /// @dev We compute the average height of the line between {xL,xU}.
-    function avgY(Line memory fn, uint256 xL, uint256 xU) internal pure returns (int256) {
-        // if the line has a zero slope, return any y
-        if (fn.y1 == fn.y2) {
-            return fn.y2.toInt256();
-        }
-
-        // m = dlY/dlX
-        // c = y2 - m . x2
-        // Avg height => (yL + yU) / 2
-        //            => m . ( xL + xU ) / 2 + c
-        int256 dlY = fn.y2.toInt256() - fn.y1.toInt256();
-        int256 dlX = fn.x2.toInt256() - fn.x1.toInt256();
-        int256 c = fn.y2.toInt256() - ((fn.x2.toInt256() * dlY) / dlX);
-        return ((((xL + xU).toInt256() * dlY) / (2 * dlX)) + c);
-    }
+    using SafeCast for int256;
 
     /// @dev This function computes y for a given x on the line (fn).
     function computeY(Line memory fn, uint256 x) internal pure returns (int256) {
@@ -44,5 +33,92 @@ library LineHelpers {
         int256 dlX = fn.x2.toInt256() - fn.x1.toInt256();
         int256 c = fn.y2.toInt256() - ((fn.x2.toInt256() * dlY) / dlX);
         return (((x.toInt256() * dlY) / dlX) + c);
+    }
+
+    /// @dev We compute the average height of the line between {xL,xU}.
+    function avgY(Line memory fn, uint256 xL, uint256 xU) internal pure returns (int256) {
+        // if the line has a zero slope, return any y
+        if (fn.y1 == fn.y2) {
+            return fn.y2.toInt256();
+        }
+
+        // NOTE: There is some precision loss because we cast to int and back
+        // m = dlY/dlX
+        // c = y2 - m . x2
+        // Avg height => (yL + yU) / 2
+        //            => m . ( xL + xU ) / 2 + c
+        int256 dlY = fn.y2.toInt256() - fn.y1.toInt256();
+        int256 dlX = fn.x2.toInt256() - fn.x1.toInt256();
+        int256 c = fn.y2.toInt256() - ((fn.x2.toInt256() * dlY) / dlX);
+        return ((((xL + xU).toInt256() * dlY) / (2 * dlX)) + c);
+    }
+
+    /// @notice Computes a piecewise average value (yVal) over the domain xRange,
+    ///         based on three linear segments (fn1, fn2, fn3) that switch at xBreakPt.
+    /// @dev    The function splits the input range into up to three segments, then
+    ///         calculates a weighted average in each segment using the corresponding
+    ///         piecewise function.
+    /// @dev AI-GENERATED
+    /// @param fn1 Piecewise linear function used when x is below xBreakPt.lower.
+    /// @param fn2 Piecewise linear function used when x is between xBreakPt.lower and xBreakPt.upper.
+    /// @param fn3 Piecewise linear function used when x is above xBreakPt.upper.
+    /// @param xBreakPt Range denoting the lower and upper x thresholds.
+    /// @param xRange   The actual x-range over which we want to compute an averaged value.
+    /// @return yVal  The computed piecewise average.
+    function computePiecewiseAvgY(
+        Line memory fn1,
+        Line memory fn2,
+        Line memory fn3,
+        Range memory xBreakPt,
+        Range memory xRange
+    ) internal pure returns (int256) {
+        int256 xl = xRange.lower.toInt256();
+        int256 xu = xRange.upper.toInt256();
+        int256 bpl = xBreakPt.lower.toInt256();
+        int256 bpu = xBreakPt.upper.toInt256();
+
+        // Validate range inputs (custom errors omitted here).
+        if (xl > xu) revert InvalidRange();
+        if (xl <= bpl && xu > bpu) revert UnexpectedRangeDelta();
+
+        // ---------------------------
+        // CASE A: Entire xRange below xBreakPt.lower → use fn1
+        if (xu <= bpl) {
+            return avgY(fn1, xRange.lower, xRange.upper);
+        }
+
+        // CASE B: xRange straddles bpl but still <= bpu
+        // Blend fn1 and fn2
+        if (xl <= bpl && xu <= bpu) {
+            // w1 = portion in fn1, w2 = portion in fn2
+            int256 w1 = bpl - xl;
+            int256 w2 = xu - bpl;
+            // Weighted average across two sub-ranges
+            return
+                (avgY(fn1, xRange.lower, xBreakPt.lower) *
+                    w1 +
+                    avgY(fn2, xBreakPt.lower, xRange.upper) *
+                    w2) / (w1 + w2);
+        }
+
+        // CASE C: Fully within [bpl, bpu] → use fn2
+        if (xl > bpl && xu <= bpu) {
+            return avgY(fn2, xRange.lower, xRange.upper);
+        }
+
+        // CASE D: xRange straddles xBreakPt.upper → blend fn2 and fn3
+        if (xl <= bpu && xu > bpu) {
+            int256 w1 = bpu - xl;
+            int256 w2 = xu - bpu;
+            return
+                (avgY(fn2, xRange.lower, xBreakPt.upper) *
+                    w1 +
+                    avgY(fn3, xBreakPt.upper, xRange.upper) *
+                    w2) / (w1 + w2);
+        }
+
+        // CASE E: Entire xRange above xBreakPt.upper → use fn3
+        // (if none of the above conditions matched, we must be here)
+        return avgY(fn3, xRange.lower, xRange.upper);
     }
 }

--- a/spot-vaults/contracts/_utils/MathHelpers.sol
+++ b/spot-vaults/contracts/_utils/MathHelpers.sol
@@ -16,6 +16,11 @@ library MathHelpers {
 
     /// @dev Clips a given integer number between provided min and max unsigned integer.
     function clip(int256 n, uint256 min, uint256 max) internal pure returns (uint256) {
-        return Math.min(Math.max((n >= 0) ? n.toUint256() : 0, min), max);
+        return clip(n > 0 ? n.toUint256() : 0, min, max);
+    }
+
+    /// @dev Clips a given unsigned integer between provided min and max unsigned integer.
+    function clip(uint256 n, uint256 min, uint256 max) internal pure returns (uint256) {
+        return Math.min(Math.max(n, min), max);
     }
 }

--- a/spot-vaults/package.json
+++ b/spot-vaults/package.json
@@ -62,7 +62,7 @@
     "ethers": "^6.6.0",
     "ethers-v5": "npm:ethers@^5.7.0",
     "ganache-cli": "latest",
-    "hardhat": "^2.22.10",
+    "hardhat": "^2.22.17",
     "hardhat-gas-reporter": "latest",
     "lodash": "^4.17.21",
     "prettier": "^2.7.1",

--- a/spot-vaults/package.json
+++ b/spot-vaults/package.json
@@ -62,7 +62,7 @@
     "ethers": "^6.6.0",
     "ethers-v5": "npm:ethers@^5.7.0",
     "ganache-cli": "latest",
-    "hardhat": "^2.22.17",
+    "hardhat": "^2.22.18",
     "hardhat-gas-reporter": "latest",
     "lodash": "^4.17.21",
     "prettier": "^2.7.1",

--- a/spot-vaults/test/BillBroker_deposit_redeem.ts
+++ b/spot-vaults/test/BillBroker_deposit_redeem.ts
@@ -234,15 +234,15 @@ describe("BillBroker", function () {
       it("should return the mint amount", async function () {
         const { billBroker, usd, perp } = await loadFixture(setupContracts);
         await usd.approve(billBroker.target, usdFP("115"));
-        await perp.approve(billBroker.target, perpFP("200"));
+        await perp.approve(billBroker.target, perpFP("2000"));
         await billBroker.deposit(
           usdFP("115"),
-          perpFP("200"),
+          perpFP("2000"),
           usdFP("115"),
-          perpFP("200"),
+          perpFP("2000"),
         );
         expect(await billBroker.computeMintAmtWithUSD.staticCall(usdFP("11.5"))).to.eq(
-          lpAmtFP("10.5"),
+          lpAmtFP("10.071428571428571428571427"),
         );
       });
     });
@@ -250,20 +250,24 @@ describe("BillBroker", function () {
     describe("when swapFee > 0", function () {
       it("should return the mint amount", async function () {
         const { billBroker, usd, perp } = await loadFixture(setupContracts);
+        await billBroker.updateARBounds(
+          [percFP("0.9"), percFP("1.1")],
+          [percFP("0.25"), percFP("4")],
+        );
         await usd.approve(billBroker.target, usdFP("115"));
-        await perp.approve(billBroker.target, perpFP("200"));
+        await perp.approve(billBroker.target, perpFP("2000"));
         await billBroker.deposit(
           usdFP("115"),
-          perpFP("200"),
+          perpFP("2000"),
           usdFP("115"),
-          perpFP("200"),
+          perpFP("2000"),
         );
         await billBroker.updateFees({
           mintFeePerc: 0n,
           burnFeePerc: 0n,
           perpToUSDSwapFeeFactors: {
             lower: percFP("1"),
-            upper: percFP("1"),
+            upper: percFP("1.2"),
           },
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.025"),
@@ -272,7 +276,7 @@ describe("BillBroker", function () {
           protocolSwapSharePerc: 0n,
         });
         expect(await billBroker.computeMintAmtWithUSD.staticCall(usdFP("11.5"))).to.eq(
-          lpAmtFP("10.3337499847826086956750"),
+          lpAmtFP("11.980204248447204967542855"),
         );
       });
     });
@@ -321,16 +325,16 @@ describe("BillBroker", function () {
     describe("when fee = 0", function () {
       it("should return the mint amount", async function () {
         const { billBroker, usd, perp } = await loadFixture(setupContracts);
-        await usd.approve(billBroker.target, usdFP("200"));
+        await usd.approve(billBroker.target, usdFP("2000"));
         await perp.approve(billBroker.target, perpFP("100"));
         await billBroker.deposit(
-          usdFP("200"),
+          usdFP("2000"),
           perpFP("100"),
-          usdFP("200"),
+          usdFP("2000"),
           perpFP("100"),
         );
         expect(await billBroker.computeMintAmtWithPerp.staticCall(perpFP("10.5"))).to.eq(
-          lpAmtFP("11.5"),
+          lpAmtFP("11.989361702127659574468084"),
         );
       });
     });
@@ -338,12 +342,16 @@ describe("BillBroker", function () {
     describe("when swapFee > 0", function () {
       it("should return the mint amount", async function () {
         const { billBroker, usd, perp } = await loadFixture(setupContracts);
-        await usd.approve(billBroker.target, usdFP("200"));
+        await billBroker.updateARBounds(
+          [percFP("0.9"), percFP("1.1")],
+          [percFP("0.25"), percFP("4")],
+        );
+        await usd.approve(billBroker.target, usdFP("2000"));
         await perp.approve(billBroker.target, perpFP("100"));
         await billBroker.deposit(
-          usdFP("200"),
+          usdFP("2000"),
           perpFP("100"),
-          usdFP("200"),
+          usdFP("2000"),
           perpFP("100"),
         );
         await billBroker.updateFees({
@@ -355,12 +363,12 @@ describe("BillBroker", function () {
           },
           usdToPerpSwapFeeFactors: {
             lower: percFP("1"),
-            upper: percFP("1"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: 0n,
         });
         expect(await billBroker.computeMintAmtWithPerp.staticCall(perpFP("10.5"))).to.eq(
-          lpAmtFP("11.3284811507845238095375"),
+          lpAmtFP("14.243163296689361701442552"),
         );
       });
     });
@@ -835,7 +843,7 @@ describe("BillBroker", function () {
           burnFeePerc: 0n,
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.025"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.025"),
@@ -876,7 +884,7 @@ describe("BillBroker", function () {
           burnFeePerc: 0n,
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.025"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.025"),
@@ -1103,7 +1111,7 @@ describe("BillBroker", function () {
           },
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.025"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: 0n,
         });
@@ -1139,7 +1147,7 @@ describe("BillBroker", function () {
           },
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.025"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: 0n,
         });

--- a/spot-vaults/test/BillBroker_deposit_redeem.ts
+++ b/spot-vaults/test/BillBroker_deposit_redeem.ts
@@ -247,36 +247,6 @@ describe("BillBroker", function () {
       });
     });
 
-    describe("when mintFee > 0", function () {
-      it("should return the mint amount", async function () {
-        const { billBroker, usd, perp } = await loadFixture(setupContracts);
-        await usd.approve(billBroker.target, usdFP("115"));
-        await perp.approve(billBroker.target, perpFP("200"));
-        await billBroker.deposit(
-          usdFP("115"),
-          perpFP("200"),
-          usdFP("115"),
-          perpFP("200"),
-        );
-        await billBroker.updateFees({
-          mintFeePerc: percFP("0.1"),
-          burnFeePerc: 0n,
-          perpToUSDSwapFeeFactors: {
-            lower: percFP("1"),
-            upper: percFP("1"),
-          },
-          usdToPerpSwapFeeFactors: {
-            lower: percFP("1"),
-            upper: percFP("1"),
-          },
-          protocolSwapSharePerc: 0n,
-        });
-        expect(await billBroker.computeMintAmtWithUSD.staticCall(usdFP("11.5"))).to.eq(
-          lpAmtFP("9.45"),
-        );
-      });
-    });
-
     describe("when swapFee > 0", function () {
       it("should return the mint amount", async function () {
         const { billBroker, usd, perp } = await loadFixture(setupContracts);
@@ -302,37 +272,7 @@ describe("BillBroker", function () {
           protocolSwapSharePerc: 0n,
         });
         expect(await billBroker.computeMintAmtWithUSD.staticCall(usdFP("11.5"))).to.eq(
-          lpAmtFP("10.324999992391304347837500"),
-        );
-      });
-    });
-
-    describe("when fee > 0", function () {
-      it("should return the mint amount", async function () {
-        const { billBroker, usd, perp } = await loadFixture(setupContracts);
-        await usd.approve(billBroker.target, usdFP("115"));
-        await perp.approve(billBroker.target, perpFP("200"));
-        await billBroker.deposit(
-          usdFP("115"),
-          perpFP("200"),
-          usdFP("115"),
-          perpFP("200"),
-        );
-        await billBroker.updateFees({
-          mintFeePerc: percFP("0.1"),
-          burnFeePerc: 0n,
-          perpToUSDSwapFeeFactors: {
-            lower: percFP("1"),
-            upper: percFP("1"),
-          },
-          usdToPerpSwapFeeFactors: {
-            lower: percFP("1.025"),
-            upper: percFP("1.15"),
-          },
-          protocolSwapSharePerc: 0n,
-        });
-        expect(await billBroker.computeMintAmtWithUSD.staticCall(usdFP("11.5"))).to.eq(
-          lpAmtFP("9.292499993152173913053750"),
+          lpAmtFP("10.3337499847826086956750"),
         );
       });
     });
@@ -395,36 +335,6 @@ describe("BillBroker", function () {
       });
     });
 
-    describe("when mintFee > 0", function () {
-      it("should return the mint amount", async function () {
-        const { billBroker, usd, perp } = await loadFixture(setupContracts);
-        await usd.approve(billBroker.target, usdFP("200"));
-        await perp.approve(billBroker.target, perpFP("100"));
-        await billBroker.deposit(
-          usdFP("200"),
-          perpFP("100"),
-          usdFP("200"),
-          perpFP("100"),
-        );
-        await billBroker.updateFees({
-          mintFeePerc: percFP("0.1"),
-          burnFeePerc: 0n,
-          perpToUSDSwapFeeFactors: {
-            lower: percFP("1"),
-            upper: percFP("1"),
-          },
-          usdToPerpSwapFeeFactors: {
-            lower: percFP("1"),
-            upper: percFP("1"),
-          },
-          protocolSwapSharePerc: 0n,
-        });
-        expect(await billBroker.computeMintAmtWithPerp.staticCall(perpFP("10.5"))).to.eq(
-          lpAmtFP("10.35"),
-        );
-      });
-    });
-
     describe("when swapFee > 0", function () {
       it("should return the mint amount", async function () {
         const { billBroker, usd, perp } = await loadFixture(setupContracts);
@@ -450,37 +360,7 @@ describe("BillBroker", function () {
           protocolSwapSharePerc: 0n,
         });
         expect(await billBroker.computeMintAmtWithPerp.staticCall(perpFP("10.5"))).to.eq(
-          lpAmtFP("11.317460317451190476300000"),
-        );
-      });
-    });
-
-    describe("when fee > 0", function () {
-      it("should return the mint amount", async function () {
-        const { billBroker, usd, perp } = await loadFixture(setupContracts);
-        await usd.approve(billBroker.target, usdFP("200"));
-        await perp.approve(billBroker.target, perpFP("100"));
-        await billBroker.deposit(
-          usdFP("200"),
-          perpFP("100"),
-          usdFP("200"),
-          perpFP("100"),
-        );
-        await billBroker.updateFees({
-          mintFeePerc: percFP("0.1"),
-          burnFeePerc: 0n,
-          perpToUSDSwapFeeFactors: {
-            lower: percFP("1.025"),
-            upper: percFP("1.1"),
-          },
-          usdToPerpSwapFeeFactors: {
-            lower: percFP("1"),
-            upper: percFP("1"),
-          },
-          protocolSwapSharePerc: 0n,
-        });
-        expect(await billBroker.computeMintAmtWithPerp.staticCall(perpFP("10.5"))).to.eq(
-          lpAmtFP("10.185714285706071428670000"),
+          lpAmtFP("11.3284811507845238095375"),
         );
       });
     });
@@ -685,7 +565,7 @@ describe("BillBroker", function () {
       it("should withhold fees and mint lp tokens", async function () {
         const { billBroker, usd, perp, deployer } = await loadFixture(setupContracts);
         await billBroker.updateFees({
-          mintFeePerc: percFP("0.1"),
+          mintFeePerc: 0n,
           burnFeePerc: 0n,
           perpToUSDSwapFeeFactors: {
             lower: percFP("1"),
@@ -701,7 +581,7 @@ describe("BillBroker", function () {
         await perp.approve(billBroker.target, perpFP("100"));
         await expect(() =>
           billBroker.deposit(usdFP("115"), perpFP("100"), usdFP("115"), perpFP("100")),
-        ).to.changeTokenBalance(billBroker, deployer, lpAmtFP("193.49"));
+        ).to.changeTokenBalance(billBroker, deployer, lpAmtFP("214.99"));
       });
     });
 
@@ -951,7 +831,7 @@ describe("BillBroker", function () {
       it("should withhold fees and mint lp tokens", async function () {
         const { billBroker, usd, perp, deployer } = await loadFixture(setupContracts);
         await billBroker.updateFees({
-          mintFeePerc: percFP("0.1"),
+          mintFeePerc: 0n,
           burnFeePerc: 0n,
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.025"),
@@ -979,20 +859,20 @@ describe("BillBroker", function () {
         ).to.changeTokenBalance(
           billBroker,
           deployer,
-          lpAmtFP("7.272391298184782608695650"),
+          lpAmtFP("8.984877117391304347826085"),
         );
 
         const r = await billBroker.computeRedemptionAmts.staticCall(
-          lpAmtFP("7.272391298184782608695650"),
+          lpAmtFP("8.984877117391304347826085"),
         );
-        expect(r[0]).to.eq(usdFP("3.126324"));
-        expect(r[1]).to.eq(perpFP("5.002119538"));
+        expect(r[0]).to.eq(usdFP("3.466549"));
+        expect(r[1]).to.eq(perpFP("5.546479327"));
       });
 
       it("should be roughly equivalent to swap+deposit", async function () {
         const { billBroker, usd, perp, deployer } = await loadFixture(setupContracts);
         await billBroker.updateFees({
-          mintFeePerc: percFP("0.1"),
+          mintFeePerc: 0n,
           burnFeePerc: 0n,
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.025"),
@@ -1022,13 +902,13 @@ describe("BillBroker", function () {
         ).to.changeTokenBalance(
           billBroker,
           deployer,
-          lpAmtFP("7.274404492533015180812111"),
+          lpAmtFP("8.980746287077796519521125"),
         );
         const r = await billBroker.computeRedemptionAmts.staticCall(
-          lpAmtFP("7.274404492533015180812111"),
+          lpAmtFP("8.980746287077796519521125"),
         );
-        expect(r[0]).to.eq(usdFP("3.127168"));
-        expect(r[1]).to.eq(perpFP("5.003558573"));
+        expect(r[0]).to.eq(usdFP("3.464999"));
+        expect(r[1]).to.eq(perpFP("5.544098565"));
       });
     });
   });
@@ -1215,7 +1095,7 @@ describe("BillBroker", function () {
         );
 
         await billBroker.updateFees({
-          mintFeePerc: percFP("0.1"),
+          mintFeePerc: 0n,
           burnFeePerc: 0n,
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.025"),
@@ -1230,13 +1110,13 @@ describe("BillBroker", function () {
         await perp.approve(billBroker.target, perpFP("10"));
         await expect(() =>
           billBroker.depositPerp(perpFP("10"), percFP("1")),
-        ).to.changeTokenBalance(billBroker, deployer, lpAmtFP("9.73499999999175"));
+        ).to.changeTokenBalance(billBroker, deployer, lpAmtFP("10.825833333315"));
 
         const r = await billBroker.computeRedemptionAmts.staticCall(
-          lpAmtFP("9.73499999999175"),
+          lpAmtFP("10.825833333315"),
         );
-        expect(r[0]).to.eq(usdFP("6.590577"));
-        expect(r[1]).to.eq(perpFP("3.152015541"));
+        expect(r[0]).to.eq(usdFP("7.305613"));
+        expect(r[1]).to.eq(perpFP("3.493988865"));
       });
 
       it("should be roughly equivalent to swap+deposit", async function () {
@@ -1251,7 +1131,7 @@ describe("BillBroker", function () {
         );
 
         await billBroker.updateFees({
-          mintFeePerc: percFP("0.1"),
+          mintFeePerc: 0n,
           burnFeePerc: 0n,
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.025"),
@@ -1267,17 +1147,17 @@ describe("BillBroker", function () {
         await usd.approve(billBroker.target, usdFP("15"));
         await billBroker.swapPerpsForUSD(perpFP("6"), 0n);
         await expect(() =>
-          billBroker.deposit(usdFP("7.318"), percFP("5"), 0n, 0n),
+          billBroker.deposit(usdFP("7.30"), percFP("5"), 0n, 0n),
         ).to.changeTokenBalance(
           billBroker,
           deployer,
-          lpAmtFP("9.734499322576672003941371"),
+          lpAmtFP("10.789506096809951964527651"),
         );
         const r = await billBroker.computeRedemptionAmts.staticCall(
-          lpAmtFP("9.734499322576672003941371"),
+          lpAmtFP("10.789506096809951964527651"),
         );
-        expect(r[0]).to.eq(usdFP("6.607168"));
-        expect(r[1]).to.eq(perpFP("3.136794078"));
+        expect(r[0]).to.eq(usdFP("7.299999"));
+        expect(r[1]).to.eq(perpFP("3.465720140"));
       });
     });
   });

--- a/spot-vaults/test/BillBroker_swap.ts
+++ b/spot-vaults/test/BillBroker_swap.ts
@@ -10,11 +10,11 @@ async function updateFees(billBroker: Contract, fees: any) {
     ...{
       mintFeePerc: currentFees[0],
       burnFeePerc: currentFees[1],
-      perpToUSDSwapFeePercs: {
+      perpToUSDSwapFeeFactors: {
         lower: currentFees[2][0],
         upper: currentFees[2][1],
       },
-      usdToPerpSwapFeePercs: {
+      usdToPerpSwapFeeFactors: {
         lower: currentFees[3][0],
         upper: currentFees[3][1],
       },
@@ -28,28 +28,26 @@ async function checkUSDToPerpSwapAmt(
   billBroker: Contract,
   usdAmtIn: BigInt,
   reserveState: any,
-  amoutsOut: any,
+  returnVals: any,
 ) {
   const r = await billBroker[
     "computeUSDToPerpSwapAmt(uint256,(uint256,uint256,uint256,uint256))"
   ](usdAmtIn, reserveState);
-  expect(r[0]).to.eq(amoutsOut[0]);
-  expect(r[1]).to.eq(amoutsOut[1]);
-  expect(r[2]).to.eq(amoutsOut[2]);
+  expect(r[0]).to.eq(returnVals[0]);
+  expect(r[1]).to.eq(returnVals[1]);
 }
 
 async function checkPerpToUSDSwapAmt(
   billBroker: Contract,
   perpAmtIn: BigInt,
   reserveState: any,
-  amoutsOut: any,
+  returnVals: any,
 ) {
   const r = await billBroker[
     "computePerpToUSDSwapAmt(uint256,(uint256,uint256,uint256,uint256))"
   ](perpAmtIn, reserveState);
-  expect(r[0]).to.eq(amoutsOut[0]);
-  expect(r[1]).to.eq(amoutsOut[1]);
-  expect(r[2]).to.eq(amoutsOut[2]);
+  expect(r[0]).to.eq(returnVals[0]);
+  expect(r[1]).to.eq(returnVals[1]);
 }
 
 async function reserveState(billBroker: Contract) {
@@ -94,13 +92,13 @@ describe("BillBroker", function () {
     await updateFees(billBroker, {
       mintFeePerc: 0n,
       burnFeePerc: 0n,
-      perpToUSDSwapFeePercs: {
-        lower: 0n,
-        upper: 0n,
+      perpToUSDSwapFeeFactors: {
+        lower: percFP("1"),
+        upper: percFP("1"),
       },
-      usdToPerpSwapFeePercs: {
-        lower: 0n,
-        upper: 0n,
+      usdToPerpSwapFeeFactors: {
+        lower: percFP("1"),
+        upper: percFP("1"),
       },
       protocolSwapSharePerc: 0n,
     });
@@ -132,7 +130,7 @@ describe("BillBroker", function () {
         billBroker,
         usdFP("115"),
         [usdFP("115000"), perpFP("100000"), priceFP("1"), priceFP("1.15")],
-        [perpFP("100"), 0n, 0n],
+        [perpFP("100"), 0n],
       );
     });
 
@@ -142,7 +140,7 @@ describe("BillBroker", function () {
         billBroker,
         usdFP("100"),
         [usdFP("110000"), perpFP("100000"), priceFP("1"), priceFP("1")],
-        [perpFP("100"), 0n, 0n],
+        [perpFP("100"), 0n],
       );
     });
 
@@ -152,7 +150,7 @@ describe("BillBroker", function () {
         billBroker,
         usdFP("11111"),
         [usdFP("100000"), perpFP("100000"), priceFP("1"), priceFP("1")],
-        [perpFP("11111"), 0n, 0n],
+        [perpFP("11111"), 0n],
       );
     });
 
@@ -163,7 +161,7 @@ describe("BillBroker", function () {
         usdFP("11112"),
         [usdFP("100000"), perpFP("100000"), priceFP("1"), priceFP("1")],
 
-        [0n, 0n, 0n],
+        [0n, 0n],
       );
     });
 
@@ -173,7 +171,7 @@ describe("BillBroker", function () {
         billBroker,
         usdFP("100"),
         [usdFP("100000"), perpFP("100000"), priceFP("1"), priceFP("0.9")],
-        [perpFP("111.111111"), 0n, 0n],
+        [perpFP("111.111111"), 0n],
       );
     });
 
@@ -181,81 +179,104 @@ describe("BillBroker", function () {
       it("should return the perp amount and fees", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
         });
         await checkUSDToPerpSwapAmt(
           billBroker,
           usdFP("115"),
           [usdFP("115000"), perpFP("100000"), priceFP("1"), priceFP("1.15")],
-          [perpFP("95"), perpFP("5"), 0n],
+          [perpFP("95"), 0n],
         );
       });
 
       it("should return the perp amount and fees", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
         });
         await checkUSDToPerpSwapAmt(
           billBroker,
           usdFP("100"),
           [usdFP("100000"), perpFP("100000"), priceFP("1"), priceFP("1")],
-          [perpFP("95"), perpFP("5"), 0n],
+          [perpFP("95"), 0n],
         );
       });
 
       it("should return the perp amount and fees", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
         });
         await checkUSDToPerpSwapAmt(
           billBroker,
           usdFP("100"),
           [usdFP("100000"), perpFP("100000"), priceFP("1"), priceFP("0.9")],
-          [perpFP("101.460470381"), perpFP("9.650640619"), 0n],
+          [perpFP("101.46047038"), 0n],
         );
       });
 
       it("should return the perp amount and fees", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
         });
         await checkUSDToPerpSwapAmt(
           billBroker,
           usdFP("10000"),
           [usdFP("100000"), perpFP("100000"), priceFP("1"), priceFP("1")],
-          [perpFP("8491.666666667"), perpFP("1508.333333333"), 0n],
+          [perpFP("8491.666666666"), 0n],
         );
       });
 
       it("should return the perp amount and fees", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
         });
         await checkUSDToPerpSwapAmt(
           billBroker,
           usdFP("20000"),
           [usdFP("100000"), perpFP("100000"), priceFP("1"), priceFP("1")],
+          [0n, 0n],
+        );
+      });
 
-          [0n, 0n, 0n],
+      it("should return the perp amount and fees", async function () {
+        const { billBroker } = await loadFixture(setupContracts);
+        await updateFees(billBroker, {
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.025"),
+            upper: percFP("1.1"),
+          },
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
+          },
+        });
+        await billBroker.updateARBounds(
+          [percFP("0.25"), percFP("4")],
+          [percFP("0.01"), percFP("100")],
+        );
+        await checkUSDToPerpSwapAmt(
+          billBroker,
+          usdFP("10000"),
+          [usdFP("1000"), perpFP("100000"), priceFP("1"), priceFP("1")],
+          [perpFP("10074.652777777"), 0n],
         );
       });
     });
@@ -264,9 +285,9 @@ describe("BillBroker", function () {
       it("should return the perp amount and fees", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -274,7 +295,7 @@ describe("BillBroker", function () {
           billBroker,
           usdFP("115"),
           [usdFP("115000"), perpFP("100000"), priceFP("1"), priceFP("1.15")],
-          [perpFP("95"), perpFP("4.5"), perpFP("0.5")],
+          [perpFP("95"), perpFP("0.5")],
         );
       });
     });
@@ -283,7 +304,7 @@ describe("BillBroker", function () {
       it("should revert", async function () {
         const { billBroker, usd, perp } = await loadFixture(setupContracts);
 
-        await billBroker.updateARBounds([0n, ethers.MaxUint256], [0n, ethers.MaxUint256]);
+        await billBroker.updateARBounds([0n, ethers.MaxInt256], [0n, ethers.MaxInt256]);
         await usd.approve(billBroker.target, usdFP("115000"));
         await billBroker.swapUSDForPerps(usdFP("115000"), 0n);
         expect(await perp.balanceOf(billBroker.target)).to.eq(0n);
@@ -300,7 +321,7 @@ describe("BillBroker", function () {
       it("should return the swap amount", async function () {
         const { billBroker, usd, perp } = await loadFixture(setupContracts);
 
-        await billBroker.updateARBounds([0n, ethers.MaxUint256], [0n, ethers.MaxUint256]);
+        await billBroker.updateARBounds([0n, ethers.MaxInt256], [0n, ethers.MaxInt256]);
         await perp.approve(billBroker.target, perpFP("100000"));
         await billBroker.swapPerpsForUSD(perpFP("100000"), 0n);
         expect(await usd.balanceOf(billBroker.target)).to.eq(0n);
@@ -309,7 +330,7 @@ describe("BillBroker", function () {
           billBroker,
           usdFP("100"),
           [0n, perpFP("100000"), priceFP("1"), priceFP("1")],
-          [perpFP("100"), 0n, 0n],
+          [perpFP("100"), 0n],
         );
       });
     });
@@ -322,7 +343,7 @@ describe("BillBroker", function () {
         billBroker,
         perpFP("100"),
         [usdFP("115000"), perpFP("100000"), priceFP("1"), priceFP("1.15")],
-        [usdFP("115"), 0n, 0n],
+        [usdFP("115"), 0n],
       );
     });
 
@@ -332,7 +353,7 @@ describe("BillBroker", function () {
         billBroker,
         perpFP("100"),
         [usdFP("110000"), perpFP("100000"), priceFP("1"), priceFP("1")],
-        [usdFP("100"), 0n, 0n],
+        [usdFP("100"), 0n],
       );
     });
 
@@ -342,7 +363,7 @@ describe("BillBroker", function () {
         billBroker,
         perpFP("14285"),
         [usdFP("100000"), perpFP("100000"), priceFP("1"), priceFP("1")],
-        [usdFP("14285"), 0n, 0n],
+        [usdFP("14285"), 0n],
       );
     });
 
@@ -362,7 +383,7 @@ describe("BillBroker", function () {
         billBroker,
         perpFP("100"),
         [usdFP("100000"), perpFP("100000"), priceFP("1"), priceFP("0.9")],
-        [usdFP("90"), 0n, 0n],
+        [usdFP("90"), 0n],
       );
     });
 
@@ -370,81 +391,104 @@ describe("BillBroker", function () {
       it("should return the perp amount and fees", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
         });
         await checkPerpToUSDSwapAmt(
           billBroker,
           perpFP("100"),
           [usdFP("115000"), perpFP("100000"), priceFP("1"), priceFP("1.15")],
-          [usdFP("103.5"), usdFP("11.5"), 0n],
+          [usdFP("103.5"), 0n],
         );
       });
 
       it("should return the perp amount and fees", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
         });
         await checkPerpToUSDSwapAmt(
           billBroker,
           perpFP("100"),
           [usdFP("110000"), perpFP("100000"), priceFP("1"), priceFP("1")],
-          [usdFP("90"), usdFP("10"), 0n],
+          [usdFP("90"), 0n],
         );
       });
 
       it("should return the perp amount and fees", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
         });
         await checkPerpToUSDSwapAmt(
           billBroker,
           perpFP("14285"),
           [usdFP("100000"), perpFP("100000"), priceFP("1"), priceFP("1")],
-          [usdFP("11142.474991"), usdFP("3142.525009"), 0n],
+          [usdFP("11142.47499"), 0n],
         );
       });
 
       it("should return the perp amount and fees", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
         });
         await checkPerpToUSDSwapAmt(
           billBroker,
           perpFP("14286"),
           [usdFP("100000"), perpFP("100000"), priceFP("1"), priceFP("1")],
-
-          [0n, 0n, 0n],
+          [0n, 0n],
         );
       });
 
       it("should return the perp amount and fees", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
         });
         await checkPerpToUSDSwapAmt(
           billBroker,
           perpFP("100"),
           [usdFP("100000"), perpFP("100000"), priceFP("1"), priceFP("0.9")],
-          [usdFP("81"), usdFP("9"), 0n],
+          [usdFP("81"), 0n],
+        );
+      });
+
+      it("should return the perp amount and fees", async function () {
+        const { billBroker } = await loadFixture(setupContracts);
+        await updateFees(billBroker, {
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
+          },
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.025"),
+            upper: percFP("1.75"),
+          },
+        });
+        await billBroker.updateARBounds(
+          [percFP("0.25"), percFP("4")],
+          [percFP("0.01"), percFP("100")],
+        );
+        await checkPerpToUSDSwapAmt(
+          billBroker,
+          perpFP("50000"),
+          [usdFP("100000"), perpFP("1000"), priceFP("1"), priceFP("1")],
+          [usdFP("60000"), 0n],
         );
       });
     });
@@ -453,9 +497,9 @@ describe("BillBroker", function () {
       it("should return the perp amount and fees", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -463,7 +507,7 @@ describe("BillBroker", function () {
           billBroker,
           perpFP("100"),
           [usdFP("110000"), perpFP("100000"), priceFP("1"), priceFP("1")],
-          [usdFP("90"), usdFP("9"), usdFP("1")],
+          [usdFP("90"), usdFP("1")],
         );
       });
     });
@@ -471,7 +515,7 @@ describe("BillBroker", function () {
     describe("when the pool has only usd", function () {
       it("should return the swap amount", async function () {
         const { billBroker, usd, perp } = await loadFixture(setupContracts);
-        await billBroker.updateARBounds([0n, ethers.MaxUint256], [0n, ethers.MaxUint256]);
+        await billBroker.updateARBounds([0n, ethers.MaxInt256], [0n, ethers.MaxInt256]);
         await usd.approve(billBroker.target, usdFP("115000"));
         await billBroker.swapUSDForPerps(usdFP("115000"), 0n);
         expect(await perp.balanceOf(billBroker.target)).to.eq(0n);
@@ -480,7 +524,7 @@ describe("BillBroker", function () {
           billBroker,
           perpFP("100"),
           [usdFP("100000"), 0n, priceFP("1"), priceFP("1")],
-          [usdFP("100"), 0n, 0n],
+          [usdFP("100"), 0n],
         );
       });
     });
@@ -488,7 +532,7 @@ describe("BillBroker", function () {
     describe("when the pool has only perps", function () {
       it("should return the swap amount", async function () {
         const { billBroker, usd, perp } = await loadFixture(setupContracts);
-        await billBroker.updateARBounds([0n, ethers.MaxUint256], [0n, ethers.MaxUint256]);
+        await billBroker.updateARBounds([0n, ethers.MaxInt256], [0n, ethers.MaxInt256]);
         await perp.approve(billBroker.target, perpFP("100000"));
         await billBroker.swapPerpsForUSD(perpFP("100000"), 0n);
         expect(await usd.balanceOf(billBroker.target)).to.eq(0n);
@@ -587,9 +631,9 @@ describe("BillBroker", function () {
       it("should transfer usd from the user", async function () {
         const { billBroker, deployer, usd } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
         });
         await expect(() =>
@@ -599,9 +643,9 @@ describe("BillBroker", function () {
       it("should transfer perps to the user", async function () {
         const { billBroker, deployer, perp } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
         });
         await expect(() =>
@@ -611,9 +655,9 @@ describe("BillBroker", function () {
       it("should increase the reserve ar", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
         });
         expect(await assetRatio(billBroker)).to.eq(percFP("1"));
@@ -623,9 +667,9 @@ describe("BillBroker", function () {
       it("should update the reserve", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
         });
         await billBroker.swapUSDForPerps(usdFP("115"), perpFP("95"));
@@ -636,9 +680,9 @@ describe("BillBroker", function () {
       it("should emit SwapUSDForPerps", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
         });
         const r = await billBroker.reserveState.staticCall();
@@ -652,9 +696,9 @@ describe("BillBroker", function () {
       it("should transfer usd from the user", async function () {
         const { billBroker, deployer, usd } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -667,9 +711,9 @@ describe("BillBroker", function () {
           setupContracts,
         );
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -683,9 +727,9 @@ describe("BillBroker", function () {
       it("should transfer protocol fee to the owner", async function () {
         const { billBroker, perp, feeCollector } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -697,9 +741,9 @@ describe("BillBroker", function () {
       it("should increase the reserve ar", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -710,9 +754,9 @@ describe("BillBroker", function () {
       it("should update the reserve", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -724,9 +768,9 @@ describe("BillBroker", function () {
       it("should emit SwapUSDForPerps", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -741,9 +785,9 @@ describe("BillBroker", function () {
       it("should transfer usd from the user", async function () {
         const { billBroker, deployer, usd } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
         });
         await expect(() =>
@@ -753,9 +797,9 @@ describe("BillBroker", function () {
       it("should transfer perps to the user", async function () {
         const { billBroker, deployer, perp } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
         });
         await expect(() =>
@@ -766,9 +810,9 @@ describe("BillBroker", function () {
       it("should increase the reserve ar", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
         });
         expect(await assetRatio(billBroker)).to.eq(percFP("1"));
@@ -778,9 +822,9 @@ describe("BillBroker", function () {
       it("should update the reserve", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
         });
         await billBroker.swapUSDForPerps(usdFP("3795"), perpFP("3130"));
@@ -791,9 +835,9 @@ describe("BillBroker", function () {
       it("should emit SwapUSDForPerps", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
         });
         const r = await billBroker.reserveState.staticCall();
@@ -811,9 +855,9 @@ describe("BillBroker", function () {
           [percFP("0.75"), percFP("1.05")],
         );
         await updateFees(billBroker, {
-          usdToPerpSwapFeePercs: {
-            lower: percFP("0.05"),
-            upper: percFP("0.5"),
+          usdToPerpSwapFeeFactors: {
+            lower: percFP("1.05"),
+            upper: percFP("1.5"),
           },
         });
         await expect(
@@ -825,7 +869,7 @@ describe("BillBroker", function () {
     describe("when the pool has only usd", function () {
       it("should revert", async function () {
         const { billBroker, usd, perp } = await loadFixture(setupContracts);
-        await billBroker.updateARBounds([0n, ethers.MaxUint256], [0n, ethers.MaxUint256]);
+        await billBroker.updateARBounds([0n, ethers.MaxInt256], [0n, ethers.MaxInt256]);
         await usd.approve(billBroker.target, usdFP("115000"));
         await billBroker.swapUSDForPerps(usdFP("115000"), 0n);
         expect(await perp.balanceOf(billBroker.target)).to.eq(0n);
@@ -839,7 +883,7 @@ describe("BillBroker", function () {
     describe("when the pool has only perps", function () {
       it("should execute swap", async function () {
         const { billBroker, usd, perp, deployer } = await loadFixture(setupContracts);
-        await billBroker.updateARBounds([0n, ethers.MaxUint256], [0n, ethers.MaxUint256]);
+        await billBroker.updateARBounds([0n, ethers.MaxInt256], [0n, ethers.MaxInt256]);
         await perp.approve(billBroker.target, perpFP("100000"));
         await billBroker.swapPerpsForUSD(perpFP("100000"), 0n);
         expect(await usd.balanceOf(billBroker.target)).to.eq(0n);
@@ -937,9 +981,9 @@ describe("BillBroker", function () {
       it("should transfer perps from the user", async function () {
         const { billBroker, deployer, perp } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
         });
         await expect(() =>
@@ -949,9 +993,9 @@ describe("BillBroker", function () {
       it("should transfer usd to the user", async function () {
         const { billBroker, deployer, usd } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
         });
         await expect(() =>
@@ -961,9 +1005,9 @@ describe("BillBroker", function () {
       it("should increase the reserve ar", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
         });
         expect(await assetRatio(billBroker)).to.eq(percFP("1"));
@@ -973,9 +1017,9 @@ describe("BillBroker", function () {
       it("should update the reserve", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
         });
         await billBroker.swapPerpsForUSD(perpFP("100"), usdFP("103"));
@@ -986,9 +1030,9 @@ describe("BillBroker", function () {
       it("should emit SwapPerpsForUSD", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
         });
         const r = await billBroker.reserveState.staticCall();
@@ -1002,9 +1046,9 @@ describe("BillBroker", function () {
       it("should transfer perps from the user", async function () {
         const { billBroker, deployer, perp } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -1017,9 +1061,9 @@ describe("BillBroker", function () {
           setupContracts,
         );
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -1031,9 +1075,9 @@ describe("BillBroker", function () {
       it("should transfer protocol fee to the owner", async function () {
         const { billBroker, usd, feeCollector } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -1045,9 +1089,9 @@ describe("BillBroker", function () {
       it("should increase the reserve ar", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -1058,9 +1102,9 @@ describe("BillBroker", function () {
       it("should update the reserve", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -1072,9 +1116,9 @@ describe("BillBroker", function () {
       it("should emit SwapPerpsForUSD", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -1089,9 +1133,9 @@ describe("BillBroker", function () {
       it("should transfer perps from the user", async function () {
         const { billBroker, deployer, perp } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
         });
         await expect(() =>
@@ -1101,9 +1145,9 @@ describe("BillBroker", function () {
       it("should transfer usd to the user", async function () {
         const { billBroker, deployer, usd } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
         });
         await expect(() =>
@@ -1113,9 +1157,9 @@ describe("BillBroker", function () {
       it("should decrease the reserve ar", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
         });
         expect(await assetRatio(billBroker)).to.eq(percFP("1"));
@@ -1125,9 +1169,9 @@ describe("BillBroker", function () {
       it("should update the reserve", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
         });
         await billBroker.swapPerpsForUSD(perpFP("3600"), usdFP("3700"));
@@ -1145,9 +1189,9 @@ describe("BillBroker", function () {
           [percFP("0.95"), percFP("1.25")],
         );
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
         });
         await expect(
@@ -1157,9 +1201,9 @@ describe("BillBroker", function () {
       it("should emit SwapPerpsForUSD", async function () {
         const { billBroker } = await loadFixture(setupContracts);
         await updateFees(billBroker, {
-          perpToUSDSwapFeePercs: {
-            lower: percFP("0.1"),
-            upper: percFP("0.5"),
+          perpToUSDSwapFeeFactors: {
+            lower: percFP("1.1"),
+            upper: percFP("1.5"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -1173,7 +1217,7 @@ describe("BillBroker", function () {
     describe("when the pool has only usd", function () {
       it("should execute swap", async function () {
         const { billBroker, usd, perp, deployer } = await loadFixture(setupContracts);
-        await billBroker.updateARBounds([0n, ethers.MaxUint256], [0n, ethers.MaxUint256]);
+        await billBroker.updateARBounds([0n, ethers.MaxInt256], [0n, ethers.MaxInt256]);
         await usd.approve(billBroker.target, usdFP("115000"));
         await billBroker.swapUSDForPerps(usdFP("115000"), 0n);
         expect(await perp.balanceOf(billBroker.target)).to.eq(0n);
@@ -1188,7 +1232,7 @@ describe("BillBroker", function () {
     describe("when the pool has only perps", function () {
       it("should revert", async function () {
         const { billBroker, usd, perp } = await loadFixture(setupContracts);
-        await billBroker.updateARBounds([0n, ethers.MaxUint256], [0n, ethers.MaxUint256]);
+        await billBroker.updateARBounds([0n, ethers.MaxInt256], [0n, ethers.MaxInt256]);
         await perp.approve(billBroker.target, perpFP("100000"));
         await billBroker.swapPerpsForUSD(perpFP("100000"), 0n);
         expect(await usd.balanceOf(billBroker.target)).to.eq(0n);

--- a/spot-vaults/test/BillBroker_swap.ts
+++ b/spot-vaults/test/BillBroker_swap.ts
@@ -181,7 +181,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await checkUSDToPerpSwapAmt(
@@ -197,7 +197,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await checkUSDToPerpSwapAmt(
@@ -213,14 +213,14 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await checkUSDToPerpSwapAmt(
           billBroker,
           usdFP("100"),
           [usdFP("100000"), perpFP("100000"), priceFP("1"), priceFP("0.9")],
-          [perpFP("101.46047038"), 0n],
+          [perpFP("104.190527093"), 0n],
         );
       });
 
@@ -229,14 +229,14 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await checkUSDToPerpSwapAmt(
           billBroker,
           usdFP("10000"),
           [usdFP("100000"), perpFP("100000"), priceFP("1"), priceFP("1")],
-          [perpFP("8491.666666666"), 0n],
+          [perpFP("9163.888888888"), 0n],
         );
       });
 
@@ -245,7 +245,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await checkUSDToPerpSwapAmt(
@@ -265,7 +265,7 @@ describe("BillBroker", function () {
           },
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await billBroker.updateARBounds(
@@ -276,7 +276,7 @@ describe("BillBroker", function () {
           billBroker,
           usdFP("10000"),
           [usdFP("1000"), perpFP("100000"), priceFP("1"), priceFP("1")],
-          [perpFP("10074.652777777"), 0n],
+          [perpFP("10649.305555555"), 0n],
         );
       });
     });
@@ -287,7 +287,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -393,7 +393,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await checkPerpToUSDSwapAmt(
@@ -409,7 +409,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await checkPerpToUSDSwapAmt(
@@ -425,14 +425,14 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await checkPerpToUSDSwapAmt(
           billBroker,
           perpFP("14285"),
           [usdFP("100000"), perpFP("100000"), priceFP("1"), priceFP("1")],
-          [usdFP("11142.47499"), 0n],
+          [usdFP("12427.993747"), 0n],
         );
       });
 
@@ -441,7 +441,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await checkPerpToUSDSwapAmt(
@@ -457,14 +457,14 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await checkPerpToUSDSwapAmt(
           billBroker,
           perpFP("100"),
           [usdFP("100000"), perpFP("100000"), priceFP("1"), priceFP("0.9")],
-          [usdFP("81"), 0n],
+          [usdFP("81.603396"), 0n],
         );
       });
 
@@ -473,11 +473,11 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.025"),
-            upper: percFP("1.75"),
+            upper: percFP("1.2"),
           },
         });
         await billBroker.updateARBounds(
@@ -488,7 +488,7 @@ describe("BillBroker", function () {
           billBroker,
           perpFP("50000"),
           [usdFP("100000"), perpFP("1000"), priceFP("1"), priceFP("1")],
-          [usdFP("60000"), 0n],
+          [usdFP("52271.287128"), 0n],
         );
       });
     });
@@ -499,7 +499,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -633,7 +633,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await expect(() =>
@@ -645,7 +645,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await expect(() =>
@@ -657,7 +657,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         expect(await assetRatio(billBroker)).to.eq(percFP("1"));
@@ -669,7 +669,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await billBroker.swapUSDForPerps(usdFP("115"), perpFP("95"));
@@ -682,7 +682,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         const r = await billBroker.reserveState.staticCall();
@@ -698,7 +698,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -713,7 +713,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -729,7 +729,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -743,7 +743,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -756,7 +756,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -770,7 +770,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -787,7 +787,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await expect(() =>
@@ -799,7 +799,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await expect(() =>
@@ -812,7 +812,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         expect(await assetRatio(billBroker)).to.eq(percFP("1"));
@@ -824,7 +824,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await billBroker.swapUSDForPerps(usdFP("3795"), perpFP("3130"));
@@ -837,7 +837,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         const r = await billBroker.reserveState.staticCall();
@@ -857,7 +857,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           usdToPerpSwapFeeFactors: {
             lower: percFP("1.05"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await expect(
@@ -983,7 +983,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await expect(() =>
@@ -995,7 +995,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await expect(() =>
@@ -1007,7 +1007,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         expect(await assetRatio(billBroker)).to.eq(percFP("1"));
@@ -1019,7 +1019,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await billBroker.swapPerpsForUSD(perpFP("100"), usdFP("103"));
@@ -1032,7 +1032,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         const r = await billBroker.reserveState.staticCall();
@@ -1048,7 +1048,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -1063,7 +1063,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -1077,7 +1077,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -1091,7 +1091,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -1104,7 +1104,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -1118,7 +1118,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });
@@ -1135,7 +1135,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await expect(() =>
@@ -1147,7 +1147,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await expect(() =>
@@ -1159,7 +1159,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         expect(await assetRatio(billBroker)).to.eq(percFP("1"));
@@ -1171,7 +1171,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await billBroker.swapPerpsForUSD(perpFP("3600"), usdFP("3700"));
@@ -1191,7 +1191,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
         });
         await expect(
@@ -1203,7 +1203,7 @@ describe("BillBroker", function () {
         await updateFees(billBroker, {
           perpToUSDSwapFeeFactors: {
             lower: percFP("1.1"),
-            upper: percFP("1.5"),
+            upper: percFP("1.2"),
           },
           protocolSwapSharePerc: percFP("0.1"),
         });

--- a/spot-vaults/test/LineHelpers.ts
+++ b/spot-vaults/test/LineHelpers.ts
@@ -1,0 +1,310 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { Contract } from "ethers";
+
+// AI generated
+describe("LineHelpers", function () {
+  let testLineHelpers: Contract;
+
+  // Deploy the test contract before running the suite
+  before(async () => {
+    const LineHelpersTester = await ethers.getContractFactory("LineHelpersTester");
+    testLineHelpers = await LineHelpersTester.deploy();
+  });
+
+  //
+  // Helper for constructing the `Line` struct in TypeScript
+  //
+  function makeLine(x1: number, y1: number, x2: number, y2: number) {
+    return { x1, y1, x2, y2 };
+  }
+
+  //
+  // Helper for constructing the `Range` struct in TypeScript
+  //
+  function makeRange(lower: number, upper: number) {
+    return { lower, upper };
+  }
+
+  // ---------------------------------------------------------------------
+  // 1. Tests for `avgY`
+  // ---------------------------------------------------------------------
+  describe("avgY", function () {
+    it("handles zero slope correctly", async () => {
+      const fn = makeLine(0, 100, 10, 100); // zero slope
+      const yAvg = await testLineHelpers.testAvgY(fn, 0, 10);
+      expect(yAvg).to.equal(100);
+
+      // Subrange
+      const yAvgSub = await testLineHelpers.testAvgY(fn, 2, 5);
+      expect(yAvgSub).to.equal(100);
+    });
+
+    it("handles positive slope", async () => {
+      // slope = (200 - 100)/(10 - 0) = 10
+      const fn = makeLine(0, 100, 10, 200);
+      // avg from x=0..10 => (100 + 200)/2 = 150
+      const yAvg = await testLineHelpers.testAvgY(fn, 0, 10);
+      expect(yAvg).to.equal(150);
+    });
+
+    it("handles negative slope", async () => {
+      // slope = (50 - 100)/(10 - 0) = -5
+      const fn = makeLine(0, 100, 10, 50);
+      // avg from x=0..10 => (100 + 50)/2 = 75
+      const yAvg = await testLineHelpers.testAvgY(fn, 0, 10);
+      expect(yAvg).to.equal(75);
+    });
+
+    it("handles partial subrange", async () => {
+      // slope = 10
+      // from x=2 => y=120, x=5 => y=150 => avg=135
+      const fn = makeLine(0, 100, 10, 200);
+      const yAvg = await testLineHelpers.testAvgY(fn, 2, 5);
+      expect(yAvg).to.equal(135);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // 2. Tests for `computeY`
+  // ---------------------------------------------------------------------
+  describe("computeY", function () {
+    it("handles zero slope", async () => {
+      const fn = makeLine(0, 100, 10, 100);
+      const yAt5 = await testLineHelpers.testComputeY(fn, 5);
+      expect(yAt5).to.equal(100);
+    });
+
+    it("handles positive slope", async () => {
+      // slope=10 => line eq: y=10*x + 100
+      const fn = makeLine(0, 100, 10, 200);
+      const yAt5 = await testLineHelpers.testComputeY(fn, 5);
+      expect(yAt5).to.equal(150);
+    });
+
+    it("handles negative slope", async () => {
+      // slope=-5 => line eq: y=-5*x + 100
+      const fn = makeLine(0, 100, 10, 50);
+      const yAt2 = await testLineHelpers.testComputeY(fn, 2);
+      expect(yAt2).to.equal(90);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // 3. Tests for `computePiecewiseAvgY`
+  // ---------------------------------------------------------------------
+  describe("computePiecewiseAvgY", function () {
+    // Reusable lines and ranges in multiple tests
+    let fn1, fn2, fn3;
+    let xBreakPt;
+
+    beforeEach(async () => {
+      fn1 = makeLine(0, 50, 10, 100);
+      fn2 = makeLine(0, 100, 10, 200);
+      fn3 = makeLine(0, 200, 10, 300);
+      xBreakPt = makeRange(2, 8);
+    });
+
+    it("reverts when xRange.lower > xRange.upper", async () => {
+      const xRange = makeRange(10, 5); // invalid
+      await expect(
+        testLineHelpers.testComputePiecewiseAvgY(fn1, fn2, fn3, xBreakPt, xRange),
+      ).to.be.revertedWithCustomError(testLineHelpers, "InvalidRange");
+    });
+
+    it("reverts when xRange straddles from below to above breakpoints", async () => {
+      // crosses [2..8] from 1..9
+      const xRange = makeRange(1, 9);
+      await expect(
+        testLineHelpers.testComputePiecewiseAvgY(fn1, fn2, fn3, xBreakPt, xRange),
+      ).to.be.revertedWithCustomError(testLineHelpers, "UnexpectedRangeDelta");
+    });
+
+    it("uses fn1 entirely when xRange is below xBreakPt.lower", async () => {
+      // xBreakPt= [2..8], xRange= [0..1]
+      const localBreak = makeRange(2, 8);
+      const localRange = makeRange(0, 1);
+      const localFn1 = makeLine(0, 50, 10, 70); // slope ~ 2/unit
+      const localFn2 = makeLine(10, 60, 20, 200);
+      const localFn3 = makeLine(20, 200, 30, 500);
+
+      const result = await testLineHelpers.testComputePiecewiseAvgY(
+        localFn1,
+        localFn2,
+        localFn3,
+        localBreak,
+        localRange,
+      );
+      expect(result).to.equal(51);
+    });
+
+    it("uses fn3 entirely when xRange is above xBreakPt.upper", async () => {
+      // xBreakPt= [2..8], xRange= [9..10]
+      const localBreak = makeRange(2, 8);
+      const localRange = makeRange(9, 10);
+
+      // fn3 from (8,200) to (10,300)
+      // y(9)=250, y(10)=300 => avg=275
+      const localFn1 = makeLine(0, 0, 10, 0);
+      const localFn2 = makeLine(10, 0, 20, 100);
+      const localFn3 = makeLine(8, 200, 10, 300);
+
+      const result = await testLineHelpers.testComputePiecewiseAvgY(
+        localFn1,
+        localFn2,
+        localFn3,
+        localBreak,
+        localRange,
+      );
+      expect(result).to.equal(275);
+    });
+
+    it("splits range across fn1 & fn2 when straddling xBreakPt.lower", async () => {
+      // xBreakPt= [2..8], xRange= [1..5]
+      const localBreak = makeRange(2, 8);
+      const localRange = makeRange(1, 5);
+
+      // fn1 => (0,10)->(2,30), slope=10
+      //   x=1 => y=20, x=2 => y=30 => avg=25
+      // fn2 => (2,30)->(8,90), slope=10
+      //   x=2 => y=30, x=5 => y=60 => avg=45
+      // Weighted sum => (25*1) + (45*3)=160 => /4=40
+      const localFn1 = makeLine(0, 10, 2, 30);
+      const localFn2 = makeLine(2, 30, 8, 90);
+      const localFn3 = makeLine(8, 90, 10, 100);
+
+      const result = await testLineHelpers.testComputePiecewiseAvgY(
+        localFn1,
+        localFn2,
+        localFn3,
+        localBreak,
+        localRange,
+      );
+      expect(result).to.equal(40);
+    });
+
+    it("splits range across fn2 & fn3 when straddling xBreakPt.upper", async () => {
+      // xBreakPt= [2..8], xRange= [5..9]
+      const localBreak = makeRange(2, 8);
+      const localRange = makeRange(5, 9);
+
+      // fn2 => (2,30)->(8,90), slope=10
+      //   x=5 => y=60, x=8 => y=90 => avg=75
+      // fn3 => (8,90)->(10,110), slope=10
+      //   x=8 => y=90, x=9 => y=100 => avg=95
+      // Weighted sum => (75*3)+(95*1)=320 => /4=80
+      const localFn1 = makeLine(0, 10, 2, 30);
+      const localFn2 = makeLine(2, 30, 8, 90);
+      const localFn3 = makeLine(8, 90, 10, 110);
+
+      const result = await testLineHelpers.testComputePiecewiseAvgY(
+        localFn1,
+        localFn2,
+        localFn3,
+        localBreak,
+        localRange,
+      );
+      expect(result).to.equal(80);
+    });
+
+    it("uses only fn2 when xRange is fully within breakpoints", async () => {
+      // xBreakPt= [2..8], xRange= [3..7]
+      // fn2 => (2,20)->(8,80), slope=10
+      //   x=3 => y=30, x=7 => y=70 => avg=50
+      const localBreak = makeRange(2, 8);
+      const localRange = makeRange(3, 7);
+
+      const localFn1 = makeLine(0, 10, 2, 20);
+      const localFn2 = makeLine(2, 20, 8, 80);
+      const localFn3 = makeLine(8, 80, 10, 100);
+
+      const result = await testLineHelpers.testComputePiecewiseAvgY(
+        localFn1,
+        localFn2,
+        localFn3,
+        localBreak,
+        localRange,
+      );
+      expect(result).to.equal(50);
+    });
+
+    it("handles zero-length xRange exactly at xBreakPt.lower", async () => {
+      // xRange= [2..2] => a single x-value
+      // Expect to take fn1 vs fn2?
+      // Typically, a single x==2 is the boundary => By definition,
+      //   if `upper <= breakPt.lower` => we are in fn1
+      //   OR if `lower >= breakPt.lower` => we might be in fn2.
+      // This might require clarity in your design or the function.
+      // For demonstration, let's assume we define:
+      //   if x == bpl => treat as fn2 (since "below" is strictly < bpl).
+      const localRange = makeRange(2, 2);
+      // We'll set the lines so we can easily compute y(2).
+      const localFn1 = makeLine(0, 10, 2, 30); // y(2)=30
+      const localFn2 = makeLine(2, 30, 8, 90); // y(2)=30
+      // We'll see which one the code picks based on your piecewise logic
+      // For a zero-length range, the "average" is just y(2).
+
+      const result = await testLineHelpers.testComputePiecewiseAvgY(
+        localFn1,
+        localFn2,
+        fn3,
+        xBreakPt,
+        localRange,
+      );
+      // Depending on your code logic:
+      // If your code lumps x=breakPt.lower in fn1, expect 30
+      // If lumps it in fn2, also 30 in this example (coincidentally the same).
+      // If you want to ensure it's definitely fn2, you could change lines:
+      //   localFn2 = makeLine(2, 50, 8, 90) => y(2)=50
+      //   Then check if result==50 => means it's definitely fn2.
+      expect(result).to.equal(30);
+    });
+
+    it("handles zero-length xRange exactly at xBreakPt.upper", async () => {
+      // xBreakPt= [2..8], xRange= [8..8]
+      // Single point at x=8
+      // By your design, x=8 could be considered "upper edge" of fn2 or "start" of fn3.
+      const localRange = makeRange(8, 8);
+
+      // Distinguish the lines so we can confirm which is used
+      const localFn2 = makeLine(2, 20, 8, 80); // y(8)=80
+      const localFn3 = makeLine(8, 999, 10, 1000); // y(8)=999
+
+      const result = await testLineHelpers.testComputePiecewiseAvgY(
+        fn1,
+        localFn2,
+        localFn3,
+        xBreakPt,
+        localRange,
+      );
+      // Depending on how your piecewise function is coded:
+      // - If x=breakPt.upper is still "within" fn2 => expect 80
+      // - If your code lumps it with fn3 => expect 999
+      // In *your* logic, it looks like "if (xRange.lower <= bpu && xRange.upper > bpu)"
+      // is the condition for partial in fn2/fn3.
+      // But here, 8..8 is exactly <=bpu and not >bpu => might remain in fn2
+      // So I'd expect 80 given the code snippet above.
+      expect(result).to.equal(80);
+    });
+
+    it("uses only fn2 when xRange = xBreakPt exactly", async () => {
+      // xRange= [2..8], which is exactly the break range
+      // Should use fn2 entirely, no partial
+      const localRange = makeRange(2, 8);
+      // We'll define fn2 so we can test the integral average from 2..8
+      // Let's pick slope=10 again =>
+      // y(2)=20, y(8)=80 => average => (20+80)/2=50
+      const localFn2 = makeLine(2, 20, 8, 80);
+
+      const result = await testLineHelpers.testComputePiecewiseAvgY(
+        fn1,
+        localFn2,
+        fn3,
+        xBreakPt,
+        localRange,
+      );
+      // If the code lumps [2..8] wholly into fn2, we get 50
+      expect(result).to.equal(50);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,7 +157,7 @@ __metadata:
     ethers: ^6.6.0
     ethers-v5: "npm:ethers@^5.7.0"
     ganache-cli: latest
-    hardhat: ^2.22.10
+    hardhat: ^2.22.17
     hardhat-gas-reporter: latest
     lodash: ^4.17.21
     prettier: ^2.7.1
@@ -1341,10 +1341,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-darwin-arm64@npm:0.5.2":
-  version: 0.5.2
-  resolution: "@nomicfoundation/edr-darwin-arm64@npm:0.5.2"
-  checksum: f6ab386603c6e080fe7f611b739eb6d1d6a370220318b725cb582702563577150b3be14b6d0be71cb72bdb854e6992c587ecfc6833216f750eae8e7cd96de46f
+"@nomicfoundation/edr-darwin-arm64@npm:0.6.5":
+  version: 0.6.5
+  resolution: "@nomicfoundation/edr-darwin-arm64@npm:0.6.5"
+  checksum: fb4ec67761fa044156fac5bcc0540312e93c6b1a8086d9871fb88cfc880fcc0f8db58a9ae8cab0fb9b74b3cb54571053f7016039c4730f5186c088102f5a43c6
   languageName: node
   linkType: hard
 
@@ -1355,10 +1355,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-darwin-x64@npm:0.5.2":
-  version: 0.5.2
-  resolution: "@nomicfoundation/edr-darwin-x64@npm:0.5.2"
-  checksum: 6f91f6d0294c0450e0501983f1de34a48582fe93f48428bc4b798ac93bb5483a96d626c2b4c62ac91102f00c826a3f9bfa16d748301440ebe1bbb2920ba3ba6d
+"@nomicfoundation/edr-darwin-x64@npm:0.6.5":
+  version: 0.6.5
+  resolution: "@nomicfoundation/edr-darwin-x64@npm:0.6.5"
+  checksum: 31444f48aee4e9c522da4dc799665b2d11432ca9aa27510161f1833b6f566714cecf8e99649d4209556a8346ab2ae521060ebd47ce21dad31a3f2a5d053607f0
   languageName: node
   linkType: hard
 
@@ -1369,10 +1369,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-linux-arm64-gnu@npm:0.5.2":
-  version: 0.5.2
-  resolution: "@nomicfoundation/edr-linux-arm64-gnu@npm:0.5.2"
-  checksum: bd84cc2741bb2be3c3a60bae9dbb8ca7794a68b8675684c97f2c6e7310e5cba7efd1cf18d392d42481cda83fb478f83c0bd605104c5cf08bab44ec07669c3010
+"@nomicfoundation/edr-linux-arm64-gnu@npm:0.6.5":
+  version: 0.6.5
+  resolution: "@nomicfoundation/edr-linux-arm64-gnu@npm:0.6.5"
+  checksum: c7059092122dd58ad38f0fa2d577b9c822424f335c217bf11c01b05257f6de7788f9db15546d2f3cbb6ba3cf0a6062d113d093f0000fd2e13fc1e2033b39c4ad
   languageName: node
   linkType: hard
 
@@ -1383,10 +1383,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-linux-arm64-musl@npm:0.5.2":
-  version: 0.5.2
-  resolution: "@nomicfoundation/edr-linux-arm64-musl@npm:0.5.2"
-  checksum: e7f7d82f16be1b26805bd90964c456aecb4a6a1397e87d507810d37bd383064271fa63932564e725fdb30868925334338ec459fe32f84fc11206644b7b37825c
+"@nomicfoundation/edr-linux-arm64-musl@npm:0.6.5":
+  version: 0.6.5
+  resolution: "@nomicfoundation/edr-linux-arm64-musl@npm:0.6.5"
+  checksum: 4d011d07c2d63f36bea81d935eb29a41815ddc2570e60c6b62668a96442b00e03285ed7fea2afd40554ef3f4a2f45b8123d8623f05862ecc6d9a4c7c606cdff4
   languageName: node
   linkType: hard
 
@@ -1397,10 +1397,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-linux-x64-gnu@npm:0.5.2":
-  version: 0.5.2
-  resolution: "@nomicfoundation/edr-linux-x64-gnu@npm:0.5.2"
-  checksum: ec025bf75227638b6b2cd01b7ba01b3ddaddf54c4d18d25e9d0364ac621981be2aaf124f4e60a88da5c9e267adb41a660a42668e2d6c9a6a57e55e8671fc76f1
+"@nomicfoundation/edr-linux-x64-gnu@npm:0.6.5":
+  version: 0.6.5
+  resolution: "@nomicfoundation/edr-linux-x64-gnu@npm:0.6.5"
+  checksum: d20616245f643cc930c9b10e2969a550f39a506c5e77d69dca2ecfd23b23bfbae4fe63a7d8add355e2c79b3624c130270cbd24cba0ae42583b087019e7d2e3fa
   languageName: node
   linkType: hard
 
@@ -1411,10 +1411,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-linux-x64-musl@npm:0.5.2":
-  version: 0.5.2
-  resolution: "@nomicfoundation/edr-linux-x64-musl@npm:0.5.2"
-  checksum: c9ff47f72645492383b2a598675878abc029b86325e2c457db1b2c4281916e11e4ef6336c355d40ae3c1736595bc43da51cfcf1e923464011f526f4db64c245b
+"@nomicfoundation/edr-linux-x64-musl@npm:0.6.5":
+  version: 0.6.5
+  resolution: "@nomicfoundation/edr-linux-x64-musl@npm:0.6.5"
+  checksum: 4e47f0e5b5176cc500c4a5beff526688a26be69d9ac2d6176c432a7ca51da4270f3b3f6738771a13c68149c66c94dcf4b719c33cf97edf96a15ddabbbc22ba1c
   languageName: node
   linkType: hard
 
@@ -1425,10 +1425,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-win32-x64-msvc@npm:0.5.2":
-  version: 0.5.2
-  resolution: "@nomicfoundation/edr-win32-x64-msvc@npm:0.5.2"
-  checksum: 56da7a1283470dede413cda5f2fef96e10250ec7a25562254ca0cd8045a653212c91e40fbcf37330e7af4e036d3c3aed83ea617831f9c7a5424389c73c53ed4e
+"@nomicfoundation/edr-win32-x64-msvc@npm:0.6.5":
+  version: 0.6.5
+  resolution: "@nomicfoundation/edr-win32-x64-msvc@npm:0.6.5"
+  checksum: ae953433f5e45e96f0448219716b7e204fc18e8b0b7f840e4158daf26e75163de528cb74940ded25b24a1f23af82993ff312ddcde120d94acecaaaf7e87f7eb7
   languageName: node
   linkType: hard
 
@@ -1447,18 +1447,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "@nomicfoundation/edr@npm:0.5.2"
+"@nomicfoundation/edr@npm:^0.6.5":
+  version: 0.6.5
+  resolution: "@nomicfoundation/edr@npm:0.6.5"
   dependencies:
-    "@nomicfoundation/edr-darwin-arm64": 0.5.2
-    "@nomicfoundation/edr-darwin-x64": 0.5.2
-    "@nomicfoundation/edr-linux-arm64-gnu": 0.5.2
-    "@nomicfoundation/edr-linux-arm64-musl": 0.5.2
-    "@nomicfoundation/edr-linux-x64-gnu": 0.5.2
-    "@nomicfoundation/edr-linux-x64-musl": 0.5.2
-    "@nomicfoundation/edr-win32-x64-msvc": 0.5.2
-  checksum: 336b1c7cad96fa78410f0c9cc9524abe9fb1e56384fe990b98bfd17f15f25b4665ad8f0525ccd9511f7c19173841fe712d50db993078629e2fc4047fda4665dc
+    "@nomicfoundation/edr-darwin-arm64": 0.6.5
+    "@nomicfoundation/edr-darwin-x64": 0.6.5
+    "@nomicfoundation/edr-linux-arm64-gnu": 0.6.5
+    "@nomicfoundation/edr-linux-arm64-musl": 0.6.5
+    "@nomicfoundation/edr-linux-x64-gnu": 0.6.5
+    "@nomicfoundation/edr-linux-x64-musl": 0.6.5
+    "@nomicfoundation/edr-win32-x64-msvc": 0.6.5
+  checksum: 5390da27b59836b64a4f5975e02dc803a70c5ba82dd29795366a79b62b53927f69d43aaf533ec0e5f56a613c29c5edea4b188059d80caf51db9cd7bd9da9fb0a
   languageName: node
   linkType: hard
 
@@ -5323,6 +5323,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chokidar@npm:^4.0.0":
+  version: 4.0.3
+  resolution: "chokidar@npm:4.0.3"
+  dependencies:
+    readdirp: ^4.0.1
+  checksum: a8765e452bbafd04f3f2fad79f04222dd65f43161488bb6014a41099e6ca18d166af613d59a90771908c1c823efa3f46ba36b86ac50b701c20c1b9908c5fe36e
+  languageName: node
+  linkType: hard
+
 "chownr@npm:^1.0.1, chownr@npm:^1.1.4":
   version: 1.1.4
   resolution: "chownr@npm:1.1.4"
@@ -8207,6 +8216,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fdir@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "fdir@npm:6.4.2"
+  peerDependencies:
+    picomatch: ^3 || ^4
+  peerDependenciesMeta:
+    picomatch:
+      optional: true
+  checksum: 517ad31c495f1c0778238eef574a7818788efaaf2ce1969ffa18c70793e2951a9763dfa2e6720b8fcef615e602a3cbb47f9b8aea9da0b02147579ab36043f22f
+  languageName: node
+  linkType: hard
+
 "fetch-ponyfill@npm:^4.0.0":
   version: 4.1.0
   resolution: "fetch-ponyfill@npm:4.1.0"
@@ -9321,13 +9342,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hardhat@npm:^2.22.10":
-  version: 2.22.10
-  resolution: "hardhat@npm:2.22.10"
+"hardhat@npm:^2.22.17":
+  version: 2.22.17
+  resolution: "hardhat@npm:2.22.17"
   dependencies:
     "@ethersproject/abi": ^5.1.2
     "@metamask/eth-sig-util": ^4.0.0
-    "@nomicfoundation/edr": ^0.5.2
+    "@nomicfoundation/edr": ^0.6.5
     "@nomicfoundation/ethereumjs-common": 4.0.4
     "@nomicfoundation/ethereumjs-tx": 5.0.4
     "@nomicfoundation/ethereumjs-util": 9.0.4
@@ -9339,31 +9360,32 @@ __metadata:
     aggregate-error: ^3.0.0
     ansi-escapes: ^4.3.0
     boxen: ^5.1.2
-    chalk: ^2.4.2
-    chokidar: ^3.4.0
+    chokidar: ^4.0.0
     ci-info: ^2.0.0
     debug: ^4.1.1
     enquirer: ^2.3.0
     env-paths: ^2.2.0
     ethereum-cryptography: ^1.0.3
     ethereumjs-abi: ^0.6.8
-    find-up: ^2.1.0
+    find-up: ^5.0.0
     fp-ts: 1.19.3
     fs-extra: ^7.0.1
-    glob: 7.2.0
     immutable: ^4.0.0-rc.12
     io-ts: 1.10.4
+    json-stream-stringify: ^3.1.4
     keccak: ^3.0.2
     lodash: ^4.17.11
     mnemonist: ^0.38.0
     mocha: ^10.0.0
     p-map: ^4.0.0
+    picocolors: ^1.1.0
     raw-body: ^2.4.1
     resolve: 1.17.0
     semver: ^6.3.0
     solc: 0.8.26
     source-map-support: ^0.5.13
     stacktrace-parser: ^0.1.10
+    tinyglobby: ^0.2.6
     tsort: 0.0.1
     undici: ^5.14.0
     uuid: ^8.3.2
@@ -9378,7 +9400,7 @@ __metadata:
       optional: true
   bin:
     hardhat: internal/cli/bootstrap.js
-  checksum: 2bb961a11f428fd025f990ea18472f4197c8352dd81f4231f27c04b7a8e94bc71d668262475102ae2c339ad83dd0e759b90ac7e4905f043be7bde471c04b5951
+  checksum: 52fe0b846c6e5808adf85c7704dfb13bfd22368f54b9ade3ba7719e60ea725a6558715f79e4eb92071ef71d1e66bdd02ff0138f71aedf3fea77784ed5ae11809
   languageName: node
   linkType: hard
 
@@ -10847,6 +10869,13 @@ __metadata:
     jsonify: ^0.0.1
     object-keys: ^1.1.1
   checksum: e1ba06600fd278767eeff53f28e408e29c867e79abf564e7aadc3ce8f31f667258f8db278ef28831e45884dd687388fa1910f46e599fc19fb94c9afbbe3a4de8
+  languageName: node
+  linkType: hard
+
+"json-stream-stringify@npm:^3.1.4":
+  version: 3.1.6
+  resolution: "json-stream-stringify@npm:3.1.6"
+  checksum: ce873e09fe18461960b7536f63e2f913a2cb242819513856ed1af58989d41846976e7177cb1fe3c835220023aa01e534d56b6d5c3290a5b23793a6f4cb93785e
   languageName: node
   linkType: hard
 
@@ -13389,10 +13418,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picocolors@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "picocolors@npm:1.1.1"
+  checksum: e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
+  languageName: node
+  linkType: hard
+
 "picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 050c865ce81119c4822c45d3c84f1ced46f93a0126febae20737bd05ca20589c564d6e9226977df859ed5e03dc73f02584a2b0faad36e896936238238b0446cf
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "picomatch@npm:4.0.2"
+  checksum: a7a5188c954f82c6585720e9143297ccd0e35ad8072231608086ca950bee672d51b0ef676254af0788205e59bd4e4deb4e7708769226bed725bf13370a7d1464
   languageName: node
   linkType: hard
 
@@ -13955,6 +13998,13 @@ __metadata:
     isarray: 0.0.1
     string_decoder: ~0.10.x
   checksum: 85042c537e4f067daa1448a7e257a201070bfec3dd2706abdbd8ebc7f3418eb4d3ed4b8e5af63e2544d69f88ab09c28d5da3c0b77dc76185fddd189a59863b60
+  languageName: node
+  linkType: hard
+
+"readdirp@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "readdirp@npm:4.0.2"
+  checksum: 309376e717f94fb7eb61bec21e2603243a9e2420cd2e9bf94ddf026aefea0d7377ed1a62f016d33265682e44908049a55c3cfc2307450a1421654ea008489b39
   languageName: node
   linkType: hard
 
@@ -15843,6 +15893,16 @@ __metadata:
     native-abort-controller: ^1.0.4
     retimer: ^3.0.0
   checksum: 7f57cb6d5f4dcdcefe9c89deacc70c07ecafdba32d51333eca6aaf91e70bbff7e6ad13d9c098480d27a6f360383685f84819a3f475a5cfe8d3f3c7da465d1da7
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.6":
+  version: 0.2.10
+  resolution: "tinyglobby@npm:0.2.10"
+  dependencies:
+    fdir: ^6.4.2
+    picomatch: ^4.0.2
+  checksum: 7e2ffe262ebc149036bdef37c56b32d02d52cf09efa7d43dbdab2ea3c12844a4da881058835ce4c74d1891190e5ad5ec5133560a11ec8314849b68ad0d99d3f4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,7 +157,7 @@ __metadata:
     ethers: ^6.6.0
     ethers-v5: "npm:ethers@^5.7.0"
     ganache-cli: latest
-    hardhat: ^2.22.17
+    hardhat: ^2.22.18
     hardhat-gas-reporter: latest
     lodash: ^4.17.21
     prettier: ^2.7.1
@@ -1341,10 +1341,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-darwin-arm64@npm:0.6.5":
-  version: 0.6.5
-  resolution: "@nomicfoundation/edr-darwin-arm64@npm:0.6.5"
-  checksum: fb4ec67761fa044156fac5bcc0540312e93c6b1a8086d9871fb88cfc880fcc0f8db58a9ae8cab0fb9b74b3cb54571053f7016039c4730f5186c088102f5a43c6
+"@nomicfoundation/edr-darwin-arm64@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@nomicfoundation/edr-darwin-arm64@npm:0.7.0"
+  checksum: 15541029227f65df2cf1df93343f6c8e9484494ddf26cf12289cea7410446ce5b2ebb9ac750a7d438276c427da7678aba0fd8fda33ed7c1e8c743955fb657055
   languageName: node
   linkType: hard
 
@@ -1355,10 +1355,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-darwin-x64@npm:0.6.5":
-  version: 0.6.5
-  resolution: "@nomicfoundation/edr-darwin-x64@npm:0.6.5"
-  checksum: 31444f48aee4e9c522da4dc799665b2d11432ca9aa27510161f1833b6f566714cecf8e99649d4209556a8346ab2ae521060ebd47ce21dad31a3f2a5d053607f0
+"@nomicfoundation/edr-darwin-x64@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@nomicfoundation/edr-darwin-x64@npm:0.7.0"
+  checksum: 4b7cbbe6e6b0484805814ca7f2151de780dfc6102d443126666a4e5a19955343cb6e709c0f99b3a80b0b07fce50d5c2cee9958c516a1c2b0f2ac568a30db1712
   languageName: node
   linkType: hard
 
@@ -1369,10 +1369,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-linux-arm64-gnu@npm:0.6.5":
-  version: 0.6.5
-  resolution: "@nomicfoundation/edr-linux-arm64-gnu@npm:0.6.5"
-  checksum: c7059092122dd58ad38f0fa2d577b9c822424f335c217bf11c01b05257f6de7788f9db15546d2f3cbb6ba3cf0a6062d113d093f0000fd2e13fc1e2033b39c4ad
+"@nomicfoundation/edr-linux-arm64-gnu@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@nomicfoundation/edr-linux-arm64-gnu@npm:0.7.0"
+  checksum: 836786bbe5f9ee9fce220c7177fd5f6565b4049e42ca8163d2676c01b211aa7c688d6662cf2e469ba44147bfeaf2152f5cc168aaba171af1507477511f3289cc
   languageName: node
   linkType: hard
 
@@ -1383,10 +1383,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-linux-arm64-musl@npm:0.6.5":
-  version: 0.6.5
-  resolution: "@nomicfoundation/edr-linux-arm64-musl@npm:0.6.5"
-  checksum: 4d011d07c2d63f36bea81d935eb29a41815ddc2570e60c6b62668a96442b00e03285ed7fea2afd40554ef3f4a2f45b8123d8623f05862ecc6d9a4c7c606cdff4
+"@nomicfoundation/edr-linux-arm64-musl@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@nomicfoundation/edr-linux-arm64-musl@npm:0.7.0"
+  checksum: 005faee82c11965430a72eaa8a55d87db0ea8b149b6d0f483b505e099152c7148a959412c387e143efc0fd51fb2221dae4e1d7004c83a9f323819db1049713f7
   languageName: node
   linkType: hard
 
@@ -1397,10 +1397,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-linux-x64-gnu@npm:0.6.5":
-  version: 0.6.5
-  resolution: "@nomicfoundation/edr-linux-x64-gnu@npm:0.6.5"
-  checksum: d20616245f643cc930c9b10e2969a550f39a506c5e77d69dca2ecfd23b23bfbae4fe63a7d8add355e2c79b3624c130270cbd24cba0ae42583b087019e7d2e3fa
+"@nomicfoundation/edr-linux-x64-gnu@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@nomicfoundation/edr-linux-x64-gnu@npm:0.7.0"
+  checksum: 18b60a0bbb7ad35240fc5f4bbe62cd83cdbc0c3e6a513d3bca3c291874d9cb02da7eb55ec3af0d8e273060347d588f80b7fbf304704c2c4cf9f7b302d4d1b466
   languageName: node
   linkType: hard
 
@@ -1411,10 +1411,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-linux-x64-musl@npm:0.6.5":
-  version: 0.6.5
-  resolution: "@nomicfoundation/edr-linux-x64-musl@npm:0.6.5"
-  checksum: 4e47f0e5b5176cc500c4a5beff526688a26be69d9ac2d6176c432a7ca51da4270f3b3f6738771a13c68149c66c94dcf4b719c33cf97edf96a15ddabbbc22ba1c
+"@nomicfoundation/edr-linux-x64-musl@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@nomicfoundation/edr-linux-x64-musl@npm:0.7.0"
+  checksum: 84e4cc834f71db02e21ea218919e9cec67983894372c232d5f36519d2d5579268d0019eb4f548826bfd1677867c78a0db81fce26bced330b375da68c91458a38
   languageName: node
   linkType: hard
 
@@ -1425,10 +1425,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-win32-x64-msvc@npm:0.6.5":
-  version: 0.6.5
-  resolution: "@nomicfoundation/edr-win32-x64-msvc@npm:0.6.5"
-  checksum: ae953433f5e45e96f0448219716b7e204fc18e8b0b7f840e4158daf26e75163de528cb74940ded25b24a1f23af82993ff312ddcde120d94acecaaaf7e87f7eb7
+"@nomicfoundation/edr-win32-x64-msvc@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@nomicfoundation/edr-win32-x64-msvc@npm:0.7.0"
+  checksum: 9f070a202cecab2d1f28353e5d90cd113ef98b9473169c83b97ab140898bd47a301a0cae69733346fe4cc57c31aa6f3796ab3280f1316aa79d561fecd00cc222
   languageName: node
   linkType: hard
 
@@ -1447,18 +1447,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr@npm:^0.6.5":
-  version: 0.6.5
-  resolution: "@nomicfoundation/edr@npm:0.6.5"
+"@nomicfoundation/edr@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@nomicfoundation/edr@npm:0.7.0"
   dependencies:
-    "@nomicfoundation/edr-darwin-arm64": 0.6.5
-    "@nomicfoundation/edr-darwin-x64": 0.6.5
-    "@nomicfoundation/edr-linux-arm64-gnu": 0.6.5
-    "@nomicfoundation/edr-linux-arm64-musl": 0.6.5
-    "@nomicfoundation/edr-linux-x64-gnu": 0.6.5
-    "@nomicfoundation/edr-linux-x64-musl": 0.6.5
-    "@nomicfoundation/edr-win32-x64-msvc": 0.6.5
-  checksum: 5390da27b59836b64a4f5975e02dc803a70c5ba82dd29795366a79b62b53927f69d43aaf533ec0e5f56a613c29c5edea4b188059d80caf51db9cd7bd9da9fb0a
+    "@nomicfoundation/edr-darwin-arm64": 0.7.0
+    "@nomicfoundation/edr-darwin-x64": 0.7.0
+    "@nomicfoundation/edr-linux-arm64-gnu": 0.7.0
+    "@nomicfoundation/edr-linux-arm64-musl": 0.7.0
+    "@nomicfoundation/edr-linux-x64-gnu": 0.7.0
+    "@nomicfoundation/edr-linux-x64-musl": 0.7.0
+    "@nomicfoundation/edr-win32-x64-msvc": 0.7.0
+  checksum: 83c54e2e2815c57ce56262f1010a0c5a2917b366bcf0acfad7662cbf2ccf46fd281e66c6db67bca9db7d91f699254216708045e882fda08c81361f111a07cb48
   languageName: node
   linkType: hard
 
@@ -9342,13 +9342,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hardhat@npm:^2.22.17":
-  version: 2.22.17
-  resolution: "hardhat@npm:2.22.17"
+"hardhat@npm:^2.22.18":
+  version: 2.22.18
+  resolution: "hardhat@npm:2.22.18"
   dependencies:
     "@ethersproject/abi": ^5.1.2
     "@metamask/eth-sig-util": ^4.0.0
-    "@nomicfoundation/edr": ^0.6.5
+    "@nomicfoundation/edr": ^0.7.0
     "@nomicfoundation/ethereumjs-common": 4.0.4
     "@nomicfoundation/ethereumjs-tx": 5.0.4
     "@nomicfoundation/ethereumjs-util": 9.0.4
@@ -9400,7 +9400,7 @@ __metadata:
       optional: true
   bin:
     hardhat: internal/cli/bootstrap.js
-  checksum: 52fe0b846c6e5808adf85c7704dfb13bfd22368f54b9ade3ba7719e60ea725a6558715f79e4eb92071ef71d1e66bdd02ff0138f71aedf3fea77784ed5ae11809
+  checksum: e350e80a96846a465e1ca0c92a30a83e5a04225b8def19c9703d049f4a05ac69ff12150f93bf647e3ce3f82e2264558c6a2cec1b8e8a8494b97ffbf241f54077
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Previously the bill broker swap fee curve was piecewise function with 2 lines. This change makes it a piecewise with 3 lines as shown in the image and now supports negative fees. 

We stored fee percentages as a unsigned fixed-point number with 18 decimals (1e18 = 100% or 1.0) which doesn't support negative fee values. Now we simply covert the existing percentages into a factor by adding 1e18. Under the new scheme:
0% => 1.0 or 1e18
100% => 2.0 or 2e18
-20% => 0.8 or 8e17

![image1](https://github.com/user-attachments/assets/e0416569-971c-4e9b-aa1f-434cad2546d0)
![image](https://github.com/user-attachments/assets/526e2d18-ab33-4e46-a280-e87de336f749)


