### PR TITLE
Restructuring perp/vault fees

### DIFF
--- a/spot-contracts/contracts/FeePolicy.sol
+++ b/spot-contracts/contracts/FeePolicy.sol
@@ -85,7 +85,7 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
     Range public drHardBound;
 
     /// @notice The deviation ratio bounds outside which flash swaps are still functional but,
-    ///         the swap fees transition from a constant fee to a linear function. disabled.
+    ///         the swap fees transition from a constant fee to a linear function.
     Range public drSoftBound;
 
     //-----------------------------------------------------------------------------

--- a/spot-contracts/contracts/FeePolicy.sol
+++ b/spot-contracts/contracts/FeePolicy.sol
@@ -2,57 +2,54 @@
 pragma solidity ^0.8.20;
 
 import { IFeePolicy } from "./_interfaces/IFeePolicy.sol";
-import { SubscriptionParams, Range, Line } from "./_interfaces/CommonTypes.sol";
-import { InvalidPerc, InvalidTargetSRBounds, InvalidDRBounds } from "./_interfaces/ProtocolErrors.sol";
+import { SubscriptionParams, Range, Line, RebalanceData } from "./_interfaces/CommonTypes.sol";
+import { InvalidPerc, InvalidTargetSRBounds, InvalidDRRange } from "./_interfaces/ProtocolErrors.sol";
 
 import { LineHelpers } from "./_utils/LineHelpers.sol";
 import { MathUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/math/MathUpgradeable.sol";
 import { SignedMathUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/math/SignedMathUpgradeable.sol";
 import { SafeCastUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
 /**
- *
  *  @title FeePolicy
  *
- *  @notice This contract determines fees for interacting with the perp and vault systems.
+ *  @notice This contract determines fees and incentives for interacting with the perp and vault systems.
  *
  *          The fee policy attempts to balance the demand for holding perp tokens with
  *          the demand for holding vault tokens; such that the total collateral in the vault
  *          supports rolling over all mature collateral backing perps.
  *
- *          Fees are computed based on the deviation between the system's current subscription ratio
- *          and the target subscription ratio.
+ *          The system's balance is defined by it's `deviationRatio` which is defined as follows.
  *              - `subscriptionRatio`   = (vaultTVL * seniorTR) / (perpTVL * 1-seniorTR)
  *              - `deviationRatio` (dr) = subscriptionRatio / targetSubscriptionRatio
  *
- *          When the system is "under-subscribed" (dr <= 1):
- *              - Rollover fees flow from perp holders to vault note holders.
- *              - Fees are charged for minting new perps.
- *              - No fees are charged for redeeming perps.
+ *          When the dr = 1, the system is considered perfectly balanced.
+ *          When the dr < 1, it's considered "under-subscribed".
+ *          When the dr > 1, it's considered "over-subscribed".
  *
- *          When the system is "over-subscribed" (dr > 1):
- *              - Rollover fees flow from vault note holders to perp holders.
- *              - No fees are charged for minting new perps.
- *              - Fees are charged for redeeming perps.
+ *          Fees:
+ *          - The system charges users a static "entry" and "exit fees", i.e) fees when users mint/redeem perps and vault notes.
+ *          - The rollover vault rents out excess liquidity if available for flash swaps for which it charges a fee.
  *
- *          Regardless of the `deviationRatio`, the system charges a fixed percentage fee
- *          for minting and redeeming vault notes.
+ *          Incentives:
+ *          - When the system is "under-subscribed", value is transferred from perp to the vault at a predefined rate.
+ *            This debases perp tokens gradually and enriches the rollover vault.
+ *          - When the system is "over-subscribed", value is transferred from the vault to perp at a predefined rate.
+ *            This enriches perp tokens gradually and debases the rollover vault.
+ *          - This transfer is implemented through a daily "rebalance" operation, executed by the vault, and
+ *            gradually nudges the system back into balance. On rebalance, the vault queries this policy
+ *            to compute the magnitude and direction of value transfer.
  *
  *
- *          The rollover fees are signed and can flow in either direction based on the `deviationRatio`.
- *          The fee function parameters are set by the owner.
- *
- *          CRITICAL: The rollover fee percentage is NOT annualized, the fee percentage is applied per rollover.
- *          The number of rollovers per year changes based on the duration of perp's minting bond.
- *
- *          We consider a `deviationRatio` of greater than 1.0 healthy (or "over-subscribed").
- *          In general, the system favors an elastic perp supply and an inelastic vault note supply.
+ *          NOTE: All parameters are stored as fixed point numbers with {DECIMALS} decimal places.
  *
  *
  */
 contract FeePolicy is IFeePolicy, OwnableUpgradeable {
     // Libraries
     using MathUpgradeable for uint256;
+    using SignedMathUpgradeable for int256;
     using SafeCastUpgradeable for uint256;
     using SafeCastUpgradeable for int256;
 
@@ -88,41 +85,17 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
     ///         the swap fees transition from a constant fee to a linear function.
     Range public drSoftBound;
 
+    /// @notice The deviation ratio bounds inside which rebalancing is disabled.
+    Range public rebalEqDr;
+
     //-----------------------------------------------------------------------------
-    // Perp fee parameters
+    // Fee parameters
 
     /// @notice The percentage fee charged on minting perp tokens.
     uint256 public perpMintFeePerc;
 
     /// @notice The percentage fee charged on burning perp tokens.
     uint256 public perpBurnFeePerc;
-
-    /// @dev NOTE: We updated the type of the parameters from int256 to uint256, which is an upgrade safe operation.
-    struct RolloverFeeParams {
-        /// @notice The minimum rollover fee percentage enforced by the contract.
-        /// @dev This is represented as signed fixed point number with {DECIMALS} places.
-        ///      The rollover fee percentage returned by the fee policy will be no lower than
-        ///      this specified value.
-        ///      The parameter effectively controls perp's maximum debasement amount.
-        int256 minRolloverFeePerc;
-        /// @notice The slope of the linear rollover fee curve when (dr <= 1).
-        /// @dev This is represented as fixed point number with {DECIMALS} places.
-        ///      Setting it to say (28 / 365), given a 28 day bond cycle it would take 1 year for dr to increase to 1.0.
-        ///      (assuming no other changes to the system)
-        uint256 perpDebasementSlope;
-        /// @notice The slope of the linear rollover fee curve when (dr > 1).
-        /// @dev This is represented as fixed point number with {DECIMALS} places.
-        ///      Setting it to say (28 / 365), given a 28 day bond cycle it would take 1 year for dr to decrease to 1.0.
-        ///      (assuming no other changes to the system)
-        uint256 perpEnrichmentSlope;
-    }
-
-    /// @notice Parameters which control the perp rollover fee,
-    ///         i.e) the funding rate for holding perps.
-    RolloverFeeParams public perpRolloverFee;
-
-    //-----------------------------------------------------------------------------
-    // Vault fee parameters
 
     /// @notice The percentage fee charged on minting vault notes.
     uint256 public vaultMintFeePerc;
@@ -135,6 +108,21 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
 
     /// @notice Lower and upper fee percentages for flash redemption.
     Range public flashRedeemFeePercs;
+
+    //-----------------------------------------------------------------------------
+    // Incentive parameters
+
+    /// @notice The percentage of system TVL transferred out of perp on every rebalance (when dr <= 1).
+    uint256 public debasementSystemTVLPerc;
+
+    /// @notice The percentage of system TVL transferred into perp on every rebalance (when dr > 1).
+    uint256 public enrichmentSystemTVLPerc;
+
+    /// @notice The percentage of the debasement value charged by the protocol as fees.
+    uint256 public debasementProtocolSharePerc;
+
+    /// @notice The percentage of the enrichment value charged by the protocol as fees.
+    uint256 public enrichmentProtocolSharePerc;
 
     //-----------------------------------------------------------------------------
 
@@ -156,23 +144,26 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
             lower: (ONE * 90) / 100, // 0.9
             upper: (5 * ONE) / 4 // 1.25
         });
+        rebalEqDr = Range({
+            lower: ONE, // 1.0
+            upper: ONE // 1.0
+        });
 
         // initializing fees
         perpMintFeePerc = 0;
         perpBurnFeePerc = 0;
-
-        // NOTE: With the current bond length of 28 days,
-        // rollover fee percentages are annualized by dividing by: 365/28 ~= 13
-        perpRolloverFee.minRolloverFeePerc = -int256(ONE) / 13; // 0.077 (-100% annualized)
-        perpRolloverFee.perpDebasementSlope = ONE / 13; // 0.077
-        perpRolloverFee.perpEnrichmentSlope = ONE / 13; // 0.077
-
         vaultMintFeePerc = 0;
         vaultBurnFeePerc = 0;
 
         // initializing swap fees to 100%, to disable swapping initially
         flashMintFeePercs = Range({ lower: ONE, upper: ONE });
         flashRedeemFeePercs = Range({ lower: ONE, upper: ONE });
+
+        // initializing incentives
+        debasementSystemTVLPerc = ONE / 1000; // 0.1% or 10 bps
+        enrichmentSystemTVLPerc = ONE / 666; // ~0.15% or 15 bps
+        debasementProtocolSharePerc = 0;
+        enrichmentProtocolSharePerc = 0;
     }
 
     //-----------------------------------------------------------------------------
@@ -195,10 +186,19 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
             drSoftBound_.lower <= drSoftBound_.upper &&
             drSoftBound_.upper <= drHardBound_.upper);
         if (!validBounds) {
-            revert InvalidDRBounds();
+            revert InvalidDRRange();
         }
         drHardBound = drHardBound_;
         drSoftBound = drSoftBound_;
+    }
+
+    /// @notice Updates rebalance equilibrium DR range within which rebalancing is disabled.
+    /// @param rebalEqDr_ The lower and upper equilibrium deviation ratio range as fixed point number with {DECIMALS} places.
+    function updateRebalanceEquilibriumDR(Range memory rebalEqDr_) external onlyOwner {
+        if (rebalEqDr_.upper < rebalEqDr_.lower || rebalEqDr_.lower > ONE || rebalEqDr_.upper < ONE) {
+            revert InvalidDRRange();
+        }
+        rebalEqDr = rebalEqDr_;
     }
 
     /// @notice Updates the perp mint fee parameters.
@@ -219,13 +219,6 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
             revert InvalidPerc();
         }
         perpBurnFeePerc = perpBurnFeePerc_;
-    }
-
-    /// @notice Update the parameters determining the rollover fee curve.
-    /// @dev Back into the per-rollover percentage based on the bond duration, and thus number of rollovers per year.
-    /// @param p Paramters are fixed point numbers with {DECIMALS} places.
-    function updatePerpRolloverFees(RolloverFeeParams calldata p) external onlyOwner {
-        perpRolloverFee = p;
     }
 
     /// @notice Updates the vault mint fee parameters.
@@ -264,6 +257,32 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
         flashRedeemFeePercs = flashRedeemFeePercs_;
     }
 
+    /// @notice Updates the rebalance rates.
+    /// @param debasementSystemTVLPerc_ The percentage of system tvl out of perp on debasement.
+    /// @param enrichmentSystemTVLPerc_ The percentage of system tvl into perp on enrichment.
+    function updateRebalanceRates(
+        uint256 debasementSystemTVLPerc_,
+        uint256 enrichmentSystemTVLPerc_
+    ) external onlyOwner {
+        debasementSystemTVLPerc = debasementSystemTVLPerc_;
+        enrichmentSystemTVLPerc = enrichmentSystemTVLPerc_;
+    }
+
+    /// @notice Updates the protocol share of the daily debasement and enrichment.
+    /// @param debasementProtocolSharePerc_ The share of the debasement which goes to the protocol.
+    /// @param enrichmentProtocolSharePerc_ The share of the enrichment which goes to the protocol.
+    function updateProtocolSharePerc(
+        uint256 debasementProtocolSharePerc_,
+        uint256 enrichmentProtocolSharePerc_
+    ) external onlyOwner {
+        if (debasementProtocolSharePerc_ > ONE || enrichmentProtocolSharePerc_ > ONE) {
+            revert InvalidPerc();
+        }
+
+        debasementProtocolSharePerc = debasementProtocolSharePerc_;
+        enrichmentProtocolSharePerc = enrichmentProtocolSharePerc_;
+    }
+
     //-----------------------------------------------------------------------------
     // Public methods
 
@@ -277,25 +296,6 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
     /// @dev Burning perps increases system dr, i.e) drPost > drPre.
     function computePerpBurnFeePerc() public view override returns (uint256) {
         return perpBurnFeePerc;
-    }
-
-    /// @inheritdoc IFeePolicy
-    function computePerpRolloverFeePerc(uint256 dr) external view override returns (int256 rolloverFeePerc) {
-        RolloverFeeParams memory c = perpRolloverFee;
-        if (dr <= ONE) {
-            // The cappedSr is the essentially the percentage of perp's collateral which can be rolled over
-            // given the vault's current liquidity level.
-            // Said simply, if cappedSr is 0.5 only 50% of the perp's collateral can be rolled over.
-            // If cappedSr is 1.0, all of perp's collateral can be rolled over.
-            uint256 cappedSr = MathUpgradeable.min(dr * targetSubscriptionRatio, ONE);
-            uint256 negRolloverFeePerc = cappedSr > 0
-                ? (ONE - dr).mulDiv(c.perpDebasementSlope, cappedSr, MathUpgradeable.Rounding.Up)
-                : c.perpDebasementSlope;
-            rolloverFeePerc = -negRolloverFeePerc.toInt256();
-        } else {
-            rolloverFeePerc = (dr - ONE).mulDiv(c.perpEnrichmentSlope, ONE).toInt256();
-        }
-        rolloverFeePerc = SignedMathUpgradeable.max(rolloverFeePerc, c.minRolloverFeePerc);
     }
 
     /// @inheritdoc IFeePolicy
@@ -379,9 +379,77 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
     }
 
     /// @inheritdoc IFeePolicy
-    function computeDeviationRatio(SubscriptionParams memory s) public view returns (uint256) {
+    function computeDeviationRatio(SubscriptionParams memory s) public view override returns (uint256) {
         // NOTE: We assume that perp's TVL and vault's TVL values have the same base denomination.
         uint256 juniorTR = TRANCHE_RATIO_GRANULARITY - s.seniorTR;
         return (s.vaultTVL * s.seniorTR).mulDiv(ONE, (s.perpTVL * juniorTR)).mulDiv(ONE, targetSubscriptionRatio);
+    }
+
+    /// @inheritdoc IFeePolicy
+    function computeRebalanceData(SubscriptionParams memory s) external view override returns (RebalanceData memory r) {
+        // We skip rebalancing if dr is close to 1.0
+        uint256 dr = computeDeviationRatio(s);
+        if (dr >= rebalEqDr.lower && dr <= rebalEqDr.upper) {
+            return r;
+        }
+
+        uint256 juniorTR = (TRANCHE_RATIO_GRANULARITY - s.seniorTR);
+        uint256 drNormalizedSeniorTR = ONE.mulDiv(
+            (s.seniorTR * ONE),
+            (s.seniorTR * ONE) + (juniorTR * targetSubscriptionRatio)
+        );
+
+        uint256 totalTVL = s.perpTVL + s.vaultTVL;
+        uint256 reqPerpTVL = totalTVL.mulDiv(drNormalizedSeniorTR, ONE);
+        r.underlyingAmtIntoPerp = reqPerpTVL.toInt256() - s.perpTVL.toInt256();
+
+        // We limit `r.underlyingAmtIntoPerp` to allowed limits
+        bool perpDebasement = r.underlyingAmtIntoPerp <= 0;
+        if (perpDebasement) {
+            r.underlyingAmtIntoPerp = SignedMathUpgradeable.max(
+                -totalTVL.mulDiv(debasementSystemTVLPerc, ONE).toInt256(),
+                r.underlyingAmtIntoPerp
+            );
+        } else {
+            r.underlyingAmtIntoPerp = SignedMathUpgradeable.min(
+                totalTVL.mulDiv(enrichmentSystemTVLPerc, ONE).toInt256(),
+                r.underlyingAmtIntoPerp
+            );
+        }
+
+        // Compute protocol fee
+        r.protocolFeeUnderlyingAmt = r.underlyingAmtIntoPerp.abs().mulDiv(
+            (perpDebasement ? debasementProtocolSharePerc : enrichmentProtocolSharePerc),
+            ONE,
+            MathUpgradeable.Rounding.Up
+        );
+
+        // Deduct protocol fee from value transfer
+        r.underlyingAmtIntoPerp -= (perpDebasement ? int256(-1) : int256(1)) * r.protocolFeeUnderlyingAmt.toInt256();
+    }
+
+    /// @inheritdoc IFeePolicy
+    function computeDREquilibriumSplit(
+        uint256 underlyingAmt,
+        uint256 seniorTR
+    ) external view override returns (uint256 perpUnderlyingAmt, uint256 vaultUnderlyingAmt) {
+        uint256 juniorTR = (TRANCHE_RATIO_GRANULARITY - seniorTR);
+        perpUnderlyingAmt = underlyingAmt.mulDiv(seniorTR, seniorTR + juniorTR.mulDiv(targetSubscriptionRatio, ONE));
+        vaultUnderlyingAmt = underlyingAmt - perpUnderlyingAmt;
+    }
+
+    /// @inheritdoc IFeePolicy
+    function computeDRNeutralSplit(
+        uint256 perpAmtAvailable,
+        uint256 vaultNoteAmtAvailable,
+        uint256 perpSupply,
+        uint256 vaultNoteSupply
+    ) external pure override returns (uint256 perpAmt, uint256 vaultNoteAmt) {
+        perpAmt = perpAmtAvailable;
+        vaultNoteAmt = vaultNoteSupply.mulDiv(perpAmt, perpSupply);
+        if (vaultNoteAmt > vaultNoteAmtAvailable) {
+            vaultNoteAmt = vaultNoteAmtAvailable;
+            perpAmt = perpAmtAvailable.mulDiv(vaultNoteAmt, vaultNoteSupply);
+        }
     }
 }

--- a/spot-contracts/contracts/PerpetualTranche.sol
+++ b/spot-contracts/contracts/PerpetualTranche.sol
@@ -35,7 +35,7 @@ import { BondHelpers } from "./_utils/BondHelpers.sol";
  *          into the reserve. At any time, the reserve holds at most 2 classes of tokens
  *          i.e) the seniors and the underlying collateral.
  *
- *          Incentivized parties can "rollover" tranches approaching maturity or the underlying collateral,
+ *          The rollover vault can "rollover" tranches approaching maturity or the underlying collateral,
  *          for newer seniors (which expire further out in the future) that belong to the updated "depositBond".
  *
  *
@@ -45,6 +45,8 @@ import { BondHelpers } from "./_utils/BondHelpers.sol";
  *      This brings the system storage state up to date.
  *
  *      CRITICAL: On the 3 main system operations: deposit, redeem and rollover;
+ *
+ *      The system charges a fee for minting and burning perp tokens, which are paid to the vault.
  *      We first compute fees before executing any transfers in or out of the system.
  *      The ordering of operations is very important as the fee computation logic,
  *      requires the system TVL as an input and which should be recorded prior to any value
@@ -56,6 +58,12 @@ import { BondHelpers } from "./_utils/BondHelpers.sol";
  *
  *      When computing the value of assets in the system, the code always over-values by
  *      rounding up. When computing the value of incoming assets, the code rounds down.
+ *
+ * @dev Demand imbalance between perp and the vault
+ *      is restored through a "rebalancing" mechanism similar to a funding rate. When value needs to flow from perp to the vault,
+ *      the system debases the value of perp tokens by minting perp tokens to the vault.
+ *      When value needs to flow from the vault to perp, the underlying collateral tokens are
+ *      transferred from the vault into perp's reserve thereby enriching the value of perp tokens.
  *
  */
 contract PerpetualTranche is
@@ -381,7 +389,7 @@ contract PerpetualTranche is
         }
 
         // Calculates the fee adjusted amount of perp tokens minted when depositing `trancheInAmt` of tranche tokens
-        // NOTE: This operation should precede any token transfers.
+        // NOTE: This calculation should precede any token transfers.
         (uint256 perpAmtMint, uint256 perpFeeAmt) = _computeMintAmt(trancheIn, trancheInAmt);
         if (trancheInAmt <= 0 || perpAmtMint <= 0) {
             return 0;
@@ -412,7 +420,7 @@ contract PerpetualTranche is
         }
 
         // Calculates the fee adjusted share of reserve tokens to be redeemed
-        // NOTE: This operation should precede any token transfers.
+        // NOTE: This calculation should precede any token transfers.
         (TokenAmount[] memory tokensOut, uint256 perpFeeAmt) = _computeRedemptionAmts(perpAmt);
 
         // burns perp tokens from the sender
@@ -443,8 +451,8 @@ contract PerpetualTranche is
             revert UnacceptableRollover();
         }
 
-        // Calculates the fee adjusted amount of tranches exchanged during a rolled over
-        // NOTE: This operation should precede any token transfers.
+        // Calculates the amount of tranches exchanged during a rolled over
+        // NOTE: This calculation should precede any token transfers.
         RolloverData memory r = _computeRolloverAmt(trancheIn, tokenOut, trancheInAmtAvailable);
 
         // Verifies if rollover amount is acceptable
@@ -459,6 +467,15 @@ contract PerpetualTranche is
         _transferOutOfReserve(tokenOut, r.tokenOutAmt);
 
         return r;
+    }
+
+    /// @inheritdoc IPerpetualTranche
+    /// @dev CAUTION: Only the whitelisted vault can call this function.
+    ///      The logic controlling the frequency and magnitude of debasement should be vetted.
+    function rebalanceToVault(
+        uint256 underlyingAmtToTransfer
+    ) external override onlyVault afterStateUpdate nonReentrant whenNotPaused {
+        _mint(address(vault), underlyingAmtToTransfer.mulDiv(totalSupply(), _reserveValue()));
     }
 
     /// @inheritdoc IPerpetualTranche
@@ -793,25 +810,11 @@ contract PerpetualTranche is
     }
 
     /// @dev Computes the amount of reserve tokens that can be rolled out for the given amount of tranches deposited.
-    ///      The relative ratios of tokens In/Out are adjusted based on the current rollover fee perc.
     function _computeRolloverAmt(
         ITranche trancheIn,
         IERC20Upgradeable tokenOut,
         uint256 trancheInAmtAvailable
     ) private view returns (RolloverData memory) {
-        //-----------------------------------------------------------------------------
-        // The rollover fees are settled by, adjusting the exchange rate
-        // between `trancheInAmt` and `tokenOutAmt`.
-        //
-        int256 feePerc = feePolicy.computePerpRolloverFeePerc(
-            feePolicy.computeDeviationRatio(
-                SubscriptionParams({
-                    perpTVL: _reserveValue(),
-                    vaultTVL: vault.getTVL(),
-                    seniorTR: _depositBond.getSeniorTrancheRatio()
-                })
-            )
-        );
         //-----------------------------------------------------------------------------
 
         // We compute "price" as the value of a unit token.
@@ -843,8 +846,8 @@ contract PerpetualTranche is
             return RolloverData({ trancheInAmt: 0, tokenOutAmt: 0 });
         }
         //-----------------------------------------------------------------------------
-        // Basic rollover with fees:
-        // (1 +/- f) . (trancheInAmt . trancheInPrice) = (tokenOutAmt . tokenOutPrice)
+        // Basic rollover:
+        // (trancheInAmt . trancheInPrice) = (tokenOutAmt . tokenOutPrice)
         //-----------------------------------------------------------------------------
 
         // Using perp's tokenOutBalance, we calculate the amount of tokens in to rollover
@@ -855,17 +858,6 @@ contract PerpetualTranche is
             trancheInAmt: tokenOutBalance.mulDiv(tokenOutPrice, trancheInPrice, MathUpgradeable.Rounding.Up)
         });
 
-        // A positive fee percentage implies that perp charges rotators by
-        // offering tranchesOut for a premium, i.e) more tranches in.
-        if (feePerc > 0) {
-            r.trancheInAmt = r.trancheInAmt.mulDiv(ONE, ONE - feePerc.toUint256(), MathUpgradeable.Rounding.Up);
-        }
-        // A negative fee percentage (or a reward) implies that perp pays the rotators by
-        // offering tranchesOut at a discount, i.e) fewer tranches in.
-        else if (feePerc < 0) {
-            r.trancheInAmt = r.trancheInAmt.mulDiv(ONE, ONE + feePerc.abs(), MathUpgradeable.Rounding.Up);
-        }
-
         //-----------------------------------------------------------------------------
 
         // When the trancheInAmt exceeds trancheInAmtAvailable:
@@ -875,19 +867,6 @@ contract PerpetualTranche is
             // Given the amount of tranches In, we compute the amount of tokens out
             r.trancheInAmt = trancheInAmtAvailable;
             r.tokenOutAmt = trancheInAmtAvailable.mulDiv(trancheInPrice, tokenOutPrice);
-
-            // A positive fee percentage implies that perp charges rotators by
-            // accepting tranchesIn at a discount, i.e) fewer tokens out.
-            // This results in perp enrichment.
-            if (feePerc > 0) {
-                r.tokenOutAmt = r.tokenOutAmt.mulDiv(ONE - feePerc.abs(), ONE);
-            }
-            // A negative fee percentage (or a reward) implies that perp pays the rotators by
-            // accepting tranchesIn at a premium, i.e) more tokens out.
-            // This results in perp debasement.
-            else if (feePerc < 0) {
-                r.tokenOutAmt = r.tokenOutAmt.mulDiv(ONE + feePerc.abs(), ONE);
-            }
         }
 
         return r;

--- a/spot-contracts/contracts/RolloverVault.sol
+++ b/spot-contracts/contracts/RolloverVault.sol
@@ -4,13 +4,16 @@ pragma solidity ^0.8.20;
 import { IERC20Upgradeable, IPerpetualTranche, IBondController, ITranche, IFeePolicy } from "./_interfaces/IPerpetualTranche.sol";
 import { IVault } from "./_interfaces/IVault.sol";
 import { IRolloverVault } from "./_interfaces/IRolloverVault.sol";
-import { TokenAmount, RolloverData, SubscriptionParams } from "./_interfaces/CommonTypes.sol";
-import { UnauthorizedCall, UnauthorizedTransferOut, UnexpectedDecimals, UnexpectedAsset, OutOfBounds, UnacceptableSwap, InsufficientDeployment, DeployedCountOverLimit, InsufficientLiquidity } from "./_interfaces/ProtocolErrors.sol";
+import { IERC20Burnable } from "./_interfaces/IERC20Burnable.sol";
+import { TokenAmount, RolloverData, SubscriptionParams, RebalanceData } from "./_interfaces/CommonTypes.sol";
+import { UnauthorizedCall, UnauthorizedTransferOut, UnexpectedDecimals, UnexpectedAsset, OutOfBounds, UnacceptableSwap, InsufficientDeployment, DeployedCountOverLimit, InsufficientLiquidity, LastRebalanceTooRecent, UnacceptableParams } from "./_interfaces/ProtocolErrors.sol";
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import { MathUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/math/MathUpgradeable.sol";
+import { SafeCastUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
+import { SignedMathUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/math/SignedMathUpgradeable.sol";
 import { ERC20BurnableUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
 import { EnumerableSetUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/structs/EnumerableSetUpgradeable.sol";
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
@@ -18,12 +21,18 @@ import { BondTranches, BondTranchesHelpers } from "./_utils/BondTranchesHelpers.
 import { TrancheHelpers } from "./_utils/TrancheHelpers.sol";
 import { BondHelpers } from "./_utils/BondHelpers.sol";
 import { PerpHelpers } from "./_utils/PerpHelpers.sol";
+import { ERC20Helpers } from "./_utils/ERC20Helpers.sol";
+import { TrancheManager } from "./_utils/TrancheManager.sol";
 
 /*
  *  @title RolloverVault
  *
- *  @notice A vault which generates yield (from fees) by performing rollovers on PerpetualTranche (or perp).
+ *  @notice A vault which performs rollovers on PerpetualTranche (or perp). After rolling over,
+ *          it holds the junior tranches to maturity, effectively becoming a perpetual junior tranche
+ *          as long as it's sufficiently capitalized.
+ *
  *          The vault takes in AMPL or any other rebasing collateral as the "underlying" asset.
+ *          It also generates a yield (from entry/exit fees, flash liquidity, and rebalancing incentives).
  *
  *          Vault strategy:
  *              1) deploy: The vault deposits the underlying asset into perp's current deposit bond
@@ -32,8 +41,13 @@ import { PerpHelpers } from "./_utils/PerpHelpers.sol";
  *              2) recover: The vault redeems the tranches it holds for the underlying asset.
  *                 NOTE: It performs both mature and immature redemption. Read more: https://bit.ly/3tuN6OC
  *
- *          With v2.0, vault provides perp<>underlying swap liquidity and charges a fee.
+ *          The vault provides perp<>underlying swap liquidity and charges a fee.
  *          The swap fees are an additional source of yield for vault note holders.
+ *
+ *          The vault has a "rebalance" operation (which can be executed at most once a day).
+ *          This is intended to balance demand for holding perp tokens with
+ *          the demand for holding vault notes, such that the vault is always sufficiently capitalized.
+ *
  *
  * @dev When new tranches are added into the system, always double check if they are not malicious
  *      by only accepting one whitelisted by perp (ones part of perp's deposit bond or ones part of the perp reserve).
@@ -58,9 +72,16 @@ contract RolloverVault is
 
     // ERC20 operations
     using SafeERC20Upgradeable for IERC20Upgradeable;
+    using SafeERC20Upgradeable for ITranche;
+    using ERC20Helpers for IERC20Upgradeable;
 
     // math
     using MathUpgradeable for uint256;
+    using SignedMathUpgradeable for int256;
+    using SafeCastUpgradeable for int256;
+
+    /// Allow linking TrancheManager
+    /// @custom:oz-upgrades-unsafe-allow external-library-linking
 
     //-------------------------------------------------------------------------
     // Events
@@ -101,7 +122,6 @@ contract RolloverVault is
     //      => { [underlying] U _deployed }
     //
     //
-
     /// @notice The ERC20 token that can be deposited into this vault.
     IERC20Upgradeable public underlying;
 
@@ -149,6 +169,15 @@ contract RolloverVault is
     ///       For more details, refer to the fee policy documentation.
     /// @custom:oz-upgrades-renamed-from minUnderlyingPerc
     uint256 public reservedSubscriptionPerc;
+
+    //--------------------------------------------------------------------------
+    // v3.0.0 STORAGE ADDITION
+
+    /// @notice Recorded timestamp of the last successful rebalance.
+    uint256 public lastRebalanceTimestampSec;
+
+    /// @notice Number of seconds after which the subsequent rebalance can be triggered.
+    uint256 public rebalanceFreqSec;
 
     //--------------------------------------------------------------------------
     // Modifiers
@@ -203,6 +232,8 @@ contract RolloverVault is
         minDeploymentAmt = 0;
         reservedUnderlyingBal = 0;
         reservedSubscriptionPerc = 0;
+        lastRebalanceTimestampSec = block.timestamp;
+        rebalanceFreqSec = 86400; // 1 day
 
         // sync underlying
         _syncAsset(underlying);
@@ -237,6 +268,12 @@ contract RolloverVault is
         keeper = keeper_;
     }
 
+    /// @notice Updates the rebalance frequency.
+    /// @param rebalanceFreqSec_ The new rebalance frequency in seconds.
+    function updateRebalanceFrequency(uint256 rebalanceFreqSec_) external onlyOwner {
+        rebalanceFreqSec = rebalanceFreqSec_;
+    }
+
     //--------------------------------------------------------------------------
     // Keeper only methods
 
@@ -250,6 +287,16 @@ contract RolloverVault is
     /// @dev NOTE: ERC-20 functions, like transfers will always remain operational.
     function unpause() external onlyKeeper {
         _unpause();
+    }
+
+    /// @notice Pauses the rebalance operation.
+    function pauseRebalance() external onlyKeeper {
+        lastRebalanceTimestampSec = type(uint256).max - rebalanceFreqSec;
+    }
+
+    /// @notice Unpauses the rebalance operation.
+    function unpauseRebalance() external onlyKeeper {
+        lastRebalanceTimestampSec = block.timestamp;
     }
 
     /// @notice Updates the minimum deployment amount requirement.
@@ -272,6 +319,15 @@ contract RolloverVault is
 
     //--------------------------------------------------------------------------
     // External & Public write methods
+
+    /// @inheritdoc IRolloverVault
+    function rebalance() external override nonReentrant whenNotPaused {
+        if (block.timestamp <= lastRebalanceTimestampSec + rebalanceFreqSec) {
+            revert LastRebalanceTooRecent();
+        }
+        _rebalance(perp, underlying);
+        lastRebalanceTimestampSec = block.timestamp;
+    }
 
     /// @inheritdoc IVault
     /// @dev Simply batches the `recover` and `deploy` functions. Reverts if there are no funds to deploy.
@@ -313,13 +369,14 @@ contract RolloverVault is
 
     /// @inheritdoc IVault
     function recover() public override nonReentrant whenNotPaused {
+        // In case the vault holds perp tokens, from rebalancing or fees,
+        // we deconstruct them into tranches.
+        IPerpetualTranche perp_ = perp;
+        _meldPerps(perp_);
+        _syncAsset(perp_);
+
         // Redeem deployed tranches
         uint8 deployedCount_ = uint8(_deployed.length());
-        if (deployedCount_ <= 0) {
-            return;
-        }
-
-        // execute redemption on each deployed asset
         for (uint8 i = 0; i < deployedCount_; ++i) {
             ITranche tranche = ITranche(_deployed.at(i));
             uint256 trancheBalance = tranche.balanceOf(address(this));
@@ -337,7 +394,7 @@ contract RolloverVault is
             // if bond has matured, redeem the tranche token
             if (bond.secondsToMaturity() <= 0) {
                 // execute redemption
-                _execMatureTrancheRedemption(bond, tranche, trancheBalance);
+                TrancheManager.execMatureTrancheRedemption(bond, tranche, trancheBalance);
             }
             // if not redeem using proportional balances
             // redeems this tranche and it's siblings if the vault holds balances.
@@ -346,7 +403,7 @@ contract RolloverVault is
             // We also skip if the tranche balance is too low as immature redemption will be a no-op.
             else if (tranche == bt.tranches[0] && trancheBalance > TRANCHE_DUST_AMT) {
                 // execute redemption
-                _execImmatureTrancheRedemption(bond, bt);
+                TrancheManager.execImmatureTrancheRedemption(bond, bt);
             }
         }
 
@@ -372,49 +429,136 @@ contract RolloverVault is
 
         IPerpetualTranche perp_ = perp;
         if (address(token) == address(perp_)) {
-            // In case the vault holds perp tokens after swaps or if transferred in erroneously,
-            // anyone can execute this function to recover perps into tranches.
-            // This is not part of the regular recovery flow.
             _meldPerps(perp_);
             _syncAsset(perp_);
             _syncAsset(underlying);
             return;
         }
+
         revert UnexpectedAsset();
+    }
+
+    /// @inheritdoc IRolloverVault
+    /// @dev This operation pushes the system back into balance, we thus charge no fees.
+    function mint2(
+        uint256 underlyingAmtIn
+    ) external override nonReentrant whenNotPaused returns (uint256 perpAmt, uint256 vaultNoteAmt) {
+        // Compute perp vault split
+        IPerpetualTranche perp_ = perp;
+        IERC20Upgradeable underlying_ = underlying;
+        SubscriptionParams memory s = _querySubscriptionState(perp_);
+        (uint256 underlyingAmtIntoPerp, uint256 underlyingAmtIntoVault) = feePolicy.computeDREquilibriumSplit(
+            underlyingAmtIn,
+            s.seniorTR
+        );
+
+        // Compute perp amount and vault note amount to mint
+        perpAmt = underlyingAmtIntoPerp.mulDiv(perp_.totalSupply(), s.perpTVL);
+        vaultNoteAmt = computeMintAmt(underlyingAmtIntoVault, 0);
+
+        // Transfer underlying tokens from user
+        underlying_.safeTransferFrom(msg.sender, address(this), underlyingAmtIn);
+
+        // Mint perps to user
+        _trancheAndMintPerps(perp_, underlying_, s.perpTVL, s.seniorTR, perpAmt);
+        IERC20Upgradeable(address(perp_)).safeTransfer(msg.sender, perpAmt);
+
+        // Mint vault notes to user
+        _mint(msg.sender, vaultNoteAmt);
+
+        // Sync underlying
+        _syncAsset(underlying_);
+    }
+
+    /// @inheritdoc IRolloverVault
+    /// @dev This operation maintains the system's balance, we thus charge no fees.
+    function redeem2(
+        uint256 perpAmtAvailable,
+        uint256 vaultNoteAmtAvailable
+    )
+        external
+        override
+        nonReentrant
+        whenNotPaused
+        returns (uint256 perpAmt, uint256 vaultNoteAmt, TokenAmount[] memory returnedTokens)
+    {
+        // Compute perp vault split
+        IPerpetualTranche perp_ = perp;
+        (perpAmt, vaultNoteAmt) = feePolicy.computeDRNeutralSplit(
+            perpAmtAvailable,
+            vaultNoteAmtAvailable,
+            perp_.totalSupply(),
+            totalSupply()
+        );
+
+        // Redeem vault notes
+        TokenAmount[] memory vaultTokens = computeRedemptionAmts(vaultNoteAmt, 0);
+        _burn(msg.sender, vaultNoteAmt);
+
+        // Transfer perps from user and redeem
+        IERC20Upgradeable(address(perp_)).safeTransferFrom(msg.sender, address(this), perpAmt);
+        TokenAmount[] memory perpTokens = perp.redeem(perpAmt);
+
+        // Compute final list of tokens to return to the user
+        // assert(underlying == perpTokens[0].token && underlying == vaultTokens[0].token);
+        returnedTokens = new TokenAmount[](perpTokens.length + vaultTokens.length - 1);
+        returnedTokens[0] = TokenAmount({
+            token: perpTokens[0].token,
+            amount: (perpTokens[0].amount + vaultTokens[0].amount)
+        });
+        returnedTokens[0].token.safeTransfer(msg.sender, returnedTokens[0].amount);
+
+        // perp tokens
+        for (uint8 i = 1; i < uint8(perpTokens.length); i++) {
+            returnedTokens[i] = perpTokens[i];
+            returnedTokens[i].token.safeTransfer(msg.sender, returnedTokens[i].amount);
+        }
+
+        // vault tokens
+        for (uint8 i = 1; i < uint8(vaultTokens.length); i++) {
+            returnedTokens[i - 1 + perpTokens.length] = vaultTokens[i];
+            vaultTokens[i].token.safeTransfer(msg.sender, vaultTokens[i].amount);
+
+            // sync balances
+            _syncDeployedAsset(vaultTokens[i].token);
+        }
+
+        // sync underlying
+        _syncAsset(perpTokens[0].token);
     }
 
     /// @inheritdoc IVault
     function deposit(uint256 underlyingAmtIn) external override nonReentrant whenNotPaused returns (uint256) {
-        // Calculates the fee adjusted amount of notes minted when depositing `underlyingAmtIn` of underlying tokens.
+        // Calculates the fee adjusted amount of vault notes minted when depositing `underlyingAmtIn` of underlying tokens.
         // NOTE: This operation should precede any token transfers.
-        uint256 notes = computeMintAmt(underlyingAmtIn);
-        if (underlyingAmtIn <= 0 || notes <= 0) {
+        uint256 vaultNoteAmt = computeMintAmt(underlyingAmtIn, feePolicy.computeVaultMintFeePerc());
+        if (underlyingAmtIn <= 0 || vaultNoteAmt <= 0) {
             return 0;
         }
 
         // transfer user assets in
         underlying.safeTransferFrom(msg.sender, address(this), underlyingAmtIn);
 
-        // mint notes
-        _mint(msg.sender, notes);
+        // mint vault notes
+        _mint(msg.sender, vaultNoteAmt);
 
         // sync underlying
         _syncAsset(underlying);
-        return notes;
+        return vaultNoteAmt;
     }
 
     /// @inheritdoc IVault
-    function redeem(uint256 notes) public override nonReentrant whenNotPaused returns (TokenAmount[] memory) {
-        if (notes <= 0) {
+    function redeem(uint256 vaultNoteAmt) public override nonReentrant whenNotPaused returns (TokenAmount[] memory) {
+        if (vaultNoteAmt <= 0) {
             return new TokenAmount[](0);
         }
 
         // Calculates the fee adjusted share of vault tokens to be redeemed
         // NOTE: This operation should precede any token transfers.
-        TokenAmount[] memory redemptions = computeRedemptionAmts(notes);
+        TokenAmount[] memory redemptions = computeRedemptionAmts(vaultNoteAmt, feePolicy.computeVaultBurnFeePerc());
 
-        // burn notes
-        _burn(msg.sender, notes);
+        // burn vault notes
+        _burn(msg.sender, vaultNoteAmt);
 
         // transfer assets out
         uint8 redemptionsCount = uint8(redemptions.length);
@@ -437,9 +581,9 @@ contract RolloverVault is
     }
 
     /// @inheritdoc IVault
-    function recoverAndRedeem(uint256 notes) external override returns (TokenAmount[] memory) {
+    function recoverAndRedeem(uint256 vaultNoteAmt) external override returns (TokenAmount[] memory) {
         recover();
-        return redeem(notes);
+        return redeem(vaultNoteAmt);
     }
 
     /// @inheritdoc IRolloverVault
@@ -586,61 +730,64 @@ contract RolloverVault is
     //--------------------------------------------------------------------------
     // External & Public read methods
 
-    /// @inheritdoc IVault
-    function computeMintAmt(uint256 underlyingAmtIn) public view returns (uint256) {
-        //-----------------------------------------------------------------------------
-        uint256 feePerc = feePolicy.computeVaultMintFeePerc();
-        //-----------------------------------------------------------------------------
-
-        // Compute mint amt
+    /// @notice Computes the amount of vault notes minted when given amount of underlying asset tokens
+    ///         are deposited into the system.
+    /// @param underlyingAmtIn The amount underlying tokens to be deposited into the vault.
+    /// @param feePerc The percentage of minted vault notes paid as fees.
+    /// @return vaultNoteAmtMint The amount of vault notes to be minted.
+    function computeMintAmt(uint256 underlyingAmtIn, uint256 feePerc) public view returns (uint256 vaultNoteAmtMint) {
         uint256 noteSupply = totalSupply();
-        uint256 notes = (noteSupply > 0)
+
+        //-----------------------------------------------------------------------------
+        // Compute mint amt
+        vaultNoteAmtMint = (noteSupply > 0)
             ? noteSupply.mulDiv(underlyingAmtIn, getTVL())
             : (underlyingAmtIn * INITIAL_RATE);
 
         // The mint fees are settled by simply minting fewer vault notes.
-        notes = notes.mulDiv(ONE - feePerc, ONE);
-        return notes;
+        vaultNoteAmtMint = vaultNoteAmtMint.mulDiv(ONE - feePerc, ONE);
     }
 
-    /// @inheritdoc IVault
-    function computeRedemptionAmts(uint256 noteAmtBurnt) public view returns (TokenAmount[] memory) {
+    /// @notice Computes the amount of asset tokens returned for redeeming vault notes.
+    /// @param vaultNoteAmtRedeemed The amount of vault notes to be redeemed.
+    /// @param feePerc The percentage of redeemed vault notes paid as fees.
+    /// @return returnedTokens The list of asset tokens and amounts returned.
+    function computeRedemptionAmts(
+        uint256 vaultNoteAmtRedeemed,
+        uint256 feePerc
+    ) public view returns (TokenAmount[] memory returnedTokens) {
         uint256 noteSupply = totalSupply();
 
-        //-----------------------------------------------------------------------------
-        uint256 feePerc = feePolicy.computeVaultBurnFeePerc();
         //-----------------------------------------------------------------------------
         uint8 assetCount_ = 1 + uint8(_deployed.length());
 
         // aggregating vault assets to be redeemed
-        TokenAmount[] memory redemptions = new TokenAmount[](assetCount_);
+        returnedTokens = new TokenAmount[](assetCount_);
 
         // underlying share to be redeemed
         IERC20Upgradeable underlying_ = underlying;
-        redemptions[0] = TokenAmount({
+        returnedTokens[0] = TokenAmount({
             token: underlying_,
-            amount: underlying_.balanceOf(address(this)).mulDiv(noteAmtBurnt, noteSupply)
+            amount: underlying_.balanceOf(address(this)).mulDiv(vaultNoteAmtRedeemed, noteSupply)
         });
-        redemptions[0].amount = redemptions[0].amount.mulDiv(ONE - feePerc, ONE);
+        returnedTokens[0].amount = returnedTokens[0].amount.mulDiv(ONE - feePerc, ONE);
 
         for (uint8 i = 1; i < assetCount_; ++i) {
             // tranche token share to be redeemed
             IERC20Upgradeable token = IERC20Upgradeable(_deployed.at(i - 1));
-            redemptions[i] = TokenAmount({
+            returnedTokens[i] = TokenAmount({
                 token: token,
-                amount: token.balanceOf(address(this)).mulDiv(noteAmtBurnt, noteSupply)
+                amount: token.balanceOf(address(this)).mulDiv(vaultNoteAmtRedeemed, noteSupply)
             });
 
             // deduct redemption fee
-            redemptions[i].amount = redemptions[i].amount.mulDiv(ONE - feePerc, ONE);
+            returnedTokens[i].amount = returnedTokens[i].amount.mulDiv(ONE - feePerc, ONE);
 
             // in case the redemption amount is just dust, we skip
-            if (redemptions[i].amount < TRANCHE_DUST_AMT) {
-                redemptions[i].amount = 0;
+            if (returnedTokens[i].amount < TRANCHE_DUST_AMT) {
+                returnedTokens[i].amount = 0;
             }
         }
-
-        return redemptions;
     }
 
     /// @inheritdoc IVault
@@ -655,7 +802,7 @@ contract RolloverVault is
             ITranche tranche = ITranche(_deployed.at(i));
             uint256 balance = tranche.balanceOf(address(this));
             if (balance > TRANCHE_DUST_AMT) {
-                totalValue += _computeVaultTrancheValue(tranche, underlying, balance);
+                totalValue += TrancheManager.computeTrancheValue(address(tranche), address(underlying), balance);
             }
         }
 
@@ -674,7 +821,10 @@ contract RolloverVault is
         // Deployed asset
         else if (_deployed.contains(address(token))) {
             ITranche tranche = ITranche(address(token));
-            return (balance > TRANCHE_DUST_AMT) ? _computeVaultTrancheValue(tranche, underlying, balance) : 0;
+            return
+                (balance > TRANCHE_DUST_AMT)
+                    ? TrancheManager.computeTrancheValue(address(tranche), address(underlying), balance)
+                    : 0;
         }
 
         // Not a vault asset, so returning zero
@@ -709,6 +859,43 @@ contract RolloverVault is
     //--------------------------------------------------------------------------
     // Private write methods
 
+    /// @dev Executes a system-level rebalance. This operation transfers value between
+    ///      the perp reserve and the vault such that the system moves toward balance.
+    ///      Settles protocol fees, charged as a percentage of the bi-directional flow in value.
+    ///      Performs some book-keeping to keep track of the vault and perp's assets.
+    function _rebalance(IPerpetualTranche perp_, IERC20Upgradeable underlying_) private {
+        // If the vault has any perp tokens we deconstruct it
+        // such that it's value reflects in the vault's TVL,
+        // before the rebalance calculation.
+        _meldPerps(perp_);
+
+        SubscriptionParams memory s = _querySubscriptionState(perp_);
+        RebalanceData memory r = feePolicy.computeRebalanceData(s);
+        if (r.underlyingAmtIntoPerp <= 0) {
+            // We transfer value from perp to the vault, by minting the vault perp tokens (without any deposits).
+            // NOTE: We first mint the vault perp tokens, and then pay the protocol fee.
+            perp_.rebalanceToVault(r.underlyingAmtIntoPerp.abs() + r.protocolFeeUnderlyingAmt);
+
+            // We immediately deconstruct perp tokens minted to the vault.
+            _meldPerps(perp_);
+        } else {
+            // We transfer value from the vault to perp, by minting the perp tokens (after making required deposit)
+            // and then simply burning the newly minted perp tokens.
+            uint256 perpAmtToTransfer = r.underlyingAmtIntoPerp.toUint256().mulDiv(perp_.totalSupply(), s.perpTVL);
+            _trancheAndMintPerps(perp_, underlying_, s.perpTVL, s.seniorTR, perpAmtToTransfer);
+            IERC20Burnable(address(perp_)).burn(perpAmtToTransfer);
+        }
+
+        // Pay protocol fees
+        if (r.protocolFeeUnderlyingAmt > 0) {
+            underlying_.safeTransfer(owner(), r.protocolFeeUnderlyingAmt);
+        }
+
+        // Sync token balances.
+        _syncAsset(perp_);
+        _syncAsset(underlying_);
+    }
+
     /// @dev Redeems tranche tokens held by the vault, for underlying.
     ///      In the case of immature redemption, this method will recover other sibling tranches as well.
     ///      Performs some book-keeping to keep track of the vault's assets.
@@ -728,7 +915,7 @@ contract RolloverVault is
         // if bond has matured, redeem the tranche token
         if (bond.secondsToMaturity() <= 0) {
             // execute redemption
-            _execMatureTrancheRedemption(bond, tranche, trancheBalance);
+            TrancheManager.execMatureTrancheRedemption(bond, tranche, trancheBalance);
 
             // sync deployed asset
             _syncDeployedAsset(tranche);
@@ -739,7 +926,7 @@ contract RolloverVault is
         else if (trancheBalance > TRANCHE_DUST_AMT) {
             // execute redemption
             BondTranches memory bt = bond.getTranches();
-            _execImmatureTrancheRedemption(bond, bt);
+            TrancheManager.execImmatureTrancheRedemption(bond, bt);
 
             // sync deployed asset, i.e) current tranche and its sibling.
             _syncDeployedAsset(bt.tranches[0]);
@@ -771,7 +958,7 @@ contract RolloverVault is
         }
     }
 
-    /// @dev Tranches the vault's underlying to mint perps..
+    /// @dev Tranches the vault's underlying to mint perps.
     ///      Performs some book-keeping to keep track of the vault's assets.
     function _trancheAndMintPerps(
         IPerpetualTranche perp_,
@@ -797,27 +984,11 @@ contract RolloverVault is
         _tranche(depositBond, underlying_, underylingAmtToTranche);
 
         // Mint perps
-        _checkAndApproveMax(trancheIntoPerp, address(perp_), seniorAmtToDeposit);
+        IERC20Upgradeable(trancheIntoPerp).checkAndApproveMax(address(perp_), seniorAmtToDeposit);
         perp_.deposit(trancheIntoPerp, seniorAmtToDeposit);
 
         // sync holdings
         _syncDeployedAsset(trancheIntoPerp);
-    }
-
-    /// @dev Given a bond and its tranche data, deposits the provided amount into the bond
-    ///      and receives tranche tokens in return.
-    ///      Performs some book-keeping to keep track of the vault's assets.
-    function _tranche(IBondController bond, IERC20Upgradeable underlying_, uint256 underlyingAmt) private {
-        // Get bond tranches
-        BondTranches memory bt = bond.getTranches();
-
-        // amount is tranched
-        _checkAndApproveMax(underlying_, address(bond), underlyingAmt);
-        bond.deposit(underlyingAmt);
-
-        // sync holdings
-        _syncDeployedAsset(bt.tranches[0]);
-        _syncDeployedAsset(bt.tranches[1]);
     }
 
     /// @dev Rolls over freshly tranched tokens from the given bond for older tranches (close to maturity) from perp.
@@ -839,7 +1010,7 @@ contract RolloverVault is
         uint256 trancheInAmtAvailable = trancheIntoPerp.balanceOf(address(this));
 
         // Approve once for all rollovers
-        _checkAndApproveMax(trancheIntoPerp, address(perp_), trancheInAmtAvailable);
+        IERC20Upgradeable(trancheIntoPerp).checkAndApproveMax(address(perp_), trancheInAmtAvailable);
 
         // We pair the senior tranche token held by the vault (from the deposit bond)
         // with each of the perp's tokens available for rollovers and execute a rollover.
@@ -878,31 +1049,16 @@ contract RolloverVault is
         return (rollover);
     }
 
-    /// @dev Low level method that redeems the given mature tranche for the underlying asset.
-    ///      It interacts with the button-wood bond contract.
-    ///      This function should NOT be called directly, use `recover()` or `_redeemTranche(tranche)`
-    ///      which wrap this function with the internal book-keeping necessary,
-    ///      to keep track of the vault's assets.
-    function _execMatureTrancheRedemption(IBondController bond, ITranche tranche, uint256 amount) private {
-        if (!bond.isMature()) {
-            bond.mature();
-        }
-        bond.redeemMature(address(tranche), amount);
-    }
+    /// @dev Given a bond, deposits the provided amount into the bond
+    ///      and receives tranche tokens in return.
+    ///      Performs some book-keeping to keep track of the vault's assets.
+    function _tranche(IBondController bond, IERC20Upgradeable underlying_, uint256 underlyingAmt) private {
+        // Tranche
+        ITranche[2] memory t = bond.approveAndDeposit(underlying_, underlyingAmt);
 
-    /// @dev Low level method that redeems the given tranche for the underlying asset, before maturity.
-    ///      If the vault holds sibling tranches with proportional balances, those will also get redeemed.
-    ///      It interacts with the button-wood bond contract.
-    ///      This function should NOT be called directly, use `recover()` or `recover(tranche)`
-    ///      which wrap this function with the internal book-keeping necessary,
-    ///      to keep track of the vault's assets.
-    function _execImmatureTrancheRedemption(IBondController bond, BondTranches memory bt) private {
-        uint256[] memory trancheAmts = bt.computeRedeemableTrancheAmounts(address(this));
-
-        // NOTE: It is guaranteed that if one tranche amount is zero, all amounts are zeros.
-        if (trancheAmts[0] > 0) {
-            bond.redeem(trancheAmts);
-        }
+        // sync holdings
+        _syncDeployedAsset(t[0]);
+        _syncDeployedAsset(t[1]);
     }
 
     /// @dev Syncs balance and updates the deployed list based on the vault's token balance.
@@ -928,14 +1084,6 @@ contract RolloverVault is
         emit AssetSynced(token, token.balanceOf(address(this)));
     }
 
-    /// @dev Checks if the spender has sufficient allowance. If not, approves the maximum possible amount.
-    function _checkAndApproveMax(IERC20Upgradeable token, address spender, uint256 amount) private {
-        uint256 allowance = token.allowance(address(this), spender);
-        if (allowance < amount) {
-            token.safeApprove(spender, type(uint256).max);
-        }
-    }
-
     /// @dev Queries the current subscription state of the perp and vault systems.
     function _querySubscriptionState(IPerpetualTranche perp_) private returns (SubscriptionParams memory) {
         return
@@ -947,21 +1095,10 @@ contract RolloverVault is
     }
 
     //--------------------------------------------------------------------------
-    // Private methods
-
-    /// @dev Computes the value of the given amount of tranche tokens, based on it's current CDR.
-    ///      Value is denominated in the underlying collateral.
-    function _computeVaultTrancheValue(
-        ITranche tranche,
-        IERC20Upgradeable collateralToken,
-        uint256 trancheAmt
-    ) private view returns (uint256) {
-        (uint256 trancheClaim, uint256 trancheSupply) = tranche.getTrancheCollateralization(collateralToken);
-        return trancheClaim.mulDiv(trancheAmt, trancheSupply, MathUpgradeable.Rounding.Up);
-    }
+    // Private view methods
 
     /// @dev Computes the balance of underlying tokens to NOT be used for any operation.
-    function _totalReservedBalance(uint256 perpTVL, uint256 seniorTR) private view returns (uint256) {
+    function _totalReservedBalance(uint256 perpTVL, uint256 seniorTR) internal view returns (uint256) {
         return
             MathUpgradeable.max(
                 reservedUnderlyingBal,

--- a/spot-contracts/contracts/_interfaces/CommonTypes.sol
+++ b/spot-contracts/contracts/_interfaces/CommonTypes.sol
@@ -27,6 +27,14 @@ struct RolloverData {
     uint256 trancheInAmt;
 }
 
+struct RebalanceData {
+    /// @notice The value in underlying tokens, that need to flow from the vault into perp.
+    /// @dev When negative, underlying tokens flow from perp into the vault.
+    int256 underlyingAmtIntoPerp;
+    /// @notice The value in underlying tokens, paid to the protocol as fees.
+    uint256 protocolFeeUnderlyingAmt;
+}
+
 /// @notice A data structure to define a numeric Range.
 struct Range {
     // @dev Lower bound of the range.

--- a/spot-contracts/contracts/_interfaces/IFeePolicy.sol
+++ b/spot-contracts/contracts/_interfaces/IFeePolicy.sol
@@ -6,10 +6,12 @@ import { SubscriptionParams } from "./CommonTypes.sol";
 interface IFeePolicy {
     /// @return The percentage of the mint perp tokens to be charged as fees,
     ///         as a fixed-point number with {DECIMALS} decimal places.
+    /// @dev Perp mint fees are paid to the vault.
     function computePerpMintFeePerc() external view returns (uint256);
 
     /// @return The percentage of the burnt perp tokens to be charged as fees,
     ///         as a fixed-point number with {DECIMALS} decimal places.
+    /// @dev Perp burn fees are paid to the vault.
     function computePerpBurnFeePerc() external view returns (uint256);
 
     /// @param dr The current system deviation ratio.

--- a/spot-contracts/contracts/_interfaces/IPerpetualTranche.sol
+++ b/spot-contracts/contracts/_interfaces/IPerpetualTranche.sol
@@ -26,6 +26,10 @@ interface IPerpetualTranche is IERC20Upgradeable {
     //--------------------------------------------------------------------------
     // Methods
 
+    /// @notice Debases the value of perp tokens, by minting new perp tokens directly to the vault.
+    /// @param underlyingAmtToTransfer The value of underlying tokens to transfer to the vault.
+    function rebalanceToVault(uint256 underlyingAmtToTransfer) external;
+
     /// @notice Deposits tranche tokens into the system and mint perp tokens.
     /// @param trancheIn The address of the tranche token to be deposited.
     /// @param trancheInAmt The amount of tranche tokens deposited.

--- a/spot-contracts/contracts/_interfaces/IRolloverVault.sol
+++ b/spot-contracts/contracts/_interfaces/IRolloverVault.sol
@@ -2,9 +2,30 @@
 pragma solidity ^0.8.0;
 
 import { IVault } from "./IVault.sol";
-import { SubscriptionParams } from "./CommonTypes.sol";
+import { SubscriptionParams, TokenAmount } from "./CommonTypes.sol";
 
 interface IRolloverVault is IVault {
+    /// @notice Gradually transfers value between the perp and vault, to bring the system back into balance.
+    /// @dev The rebalance function can be executed at-most once a day.
+    function rebalance() external;
+
+    /// @notice Batch operation to mint both perp and rollover vault tokens.
+    /// @param underlyingAmtIn The amount of underlying tokens to be tranched.
+    /// @return perpAmt The amount of perp tokens minted.
+    /// @return vaultNoteAmt The amount of vault notes minted.
+    function mint2(uint256 underlyingAmtIn) external returns (uint256 perpAmt, uint256 vaultNoteAmt);
+
+    /// @notice Batch operation to redeem both perp and rollover vault tokens for the underlying collateral and tranches.
+    /// @param perpAmtAvailable The amount of perp tokens available to redeem.
+    /// @param vaultNoteAmtAvailable The amount of vault notes available to redeem.
+    /// @return perpAmtBurnt The amount of perp tokens redeemed.
+    /// @return vaultNoteAmtBurnt The amount of vault notes redeemed.
+    /// @return returnedTokens The list of asset tokens and amounts returned.
+    function redeem2(
+        uint256 perpAmtAvailable,
+        uint256 vaultNoteAmtAvailable
+    ) external returns (uint256 perpAmtBurnt, uint256 vaultNoteAmtBurnt, TokenAmount[] memory returnedTokens);
+
     /// @notice Allows users to swap their underlying tokens for perps held by the vault.
     /// @param underlyingAmtIn The amount of underlying tokens swapped in.
     /// @return The amount of perp tokens swapped out.

--- a/spot-contracts/contracts/_interfaces/IVault.sol
+++ b/spot-contracts/contracts/_interfaces/IVault.sol
@@ -82,15 +82,4 @@ interface IVault is IERC20Upgradeable {
     /// @param token The address of a token to check.
     /// @return If the given token is held by the vault.
     function isVaultAsset(IERC20Upgradeable token) external view returns (bool);
-
-    /// @notice Computes the amount of notes minted when given amount of underlying asset tokens
-    ///         are deposited into the system.
-    /// @param amount The amount tokens to be deposited into the vault.
-    /// @return The amount of notes to be minted.
-    function computeMintAmt(uint256 amount) external returns (uint256);
-
-    /// @notice Computes the amount of asset tokens redeemed when burning given number of vault notes.
-    /// @param notes The amount of notes to be burnt.
-    /// @return The list of asset tokens and amounts redeemed.
-    function computeRedemptionAmts(uint256 notes) external returns (TokenAmount[] memory);
 }

--- a/spot-contracts/contracts/_interfaces/ProtocolErrors.sol
+++ b/spot-contracts/contracts/_interfaces/ProtocolErrors.sol
@@ -67,8 +67,11 @@ error DeployedCountOverLimit();
 /// @notice Expected parent bond to have only 2 children tranches.
 error UnacceptableTrancheLength();
 
+/// @notice Not enough time has elapsed since last successful rebalance.
+error LastRebalanceTooRecent();
+
 //-------------------------------------------------------------------------
-// Fee Policy
+// FeePolicy
 
 /// @notice Expected perc value to be at most (1 * 10**DECIMALS), i.e) 1.0 or 100%.
 error InvalidPerc();
@@ -76,5 +79,5 @@ error InvalidPerc();
 /// @notice Expected target subscription ratio to be within defined bounds.
 error InvalidTargetSRBounds();
 
-/// @notice Expected deviation ratio bounds to be valid.
-error InvalidDRBounds();
+/// @notice Expected deviation ratio range to be valid.
+error InvalidDRRange();

--- a/spot-contracts/contracts/_utils/BondHelpers.sol
+++ b/spot-contracts/contracts/_utils/BondHelpers.sol
@@ -10,6 +10,7 @@ import { UnacceptableDeposit, UnacceptableTrancheLength } from "../_interfaces/P
 import { SafeCastUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
 import { MathUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/math/MathUpgradeable.sol";
 import { BondTranches } from "./BondTranchesHelpers.sol";
+import { ERC20Helpers } from "./ERC20Helpers.sol";
 
 /**
  *  @title BondHelpers
@@ -20,6 +21,7 @@ import { BondTranches } from "./BondTranchesHelpers.sol";
 library BondHelpers {
     using SafeCastUpgradeable for uint256;
     using MathUpgradeable for uint256;
+    using ERC20Helpers for IERC20Upgradeable;
 
     // Replicating value used here:
     // https://github.com/buttonwood-protocol/tranche/blob/main/contracts/BondController.sol
@@ -96,5 +98,18 @@ library BondHelpers {
         tranchesOut[1] = TokenAmount({ token: bt.tranches[1], amount: juniorAmt });
 
         return tranchesOut;
+    }
+
+    /// @notice Helper function which approves underlying tokens and mints tranche tokens by depositing into the provided bond contract.
+    /// @return The array of tranche tokens minted.
+    function approveAndDeposit(
+        IBondController b,
+        IERC20Upgradeable underlying_,
+        uint256 underlyingAmt
+    ) internal returns (ITranche[2] memory) {
+        BondTranches memory bt = getTranches(b);
+        underlying_.checkAndApproveMax(address(b), underlyingAmt);
+        b.deposit(underlyingAmt);
+        return bt.tranches;
     }
 }

--- a/spot-contracts/contracts/_utils/ERC20Helpers.sol
+++ b/spot-contracts/contracts/_utils/ERC20Helpers.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+
+/**
+ *  @title ERC20Helpers
+ *
+ *  @notice Library with helper functions for ERC20 Tokens.
+ *
+ */
+library ERC20Helpers {
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    /// @notice Checks if the spender has sufficient allowance. If not, approves the maximum possible amount.
+    function checkAndApproveMax(IERC20Upgradeable token, address spender, uint256 amount) internal {
+        uint256 allowance = token.allowance(address(this), spender);
+        if (allowance < amount) {
+            token.safeApprove(spender, type(uint256).max);
+        }
+    }
+}

--- a/spot-contracts/contracts/_utils/TrancheManager.sol
+++ b/spot-contracts/contracts/_utils/TrancheManager.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.20;
+
+import { IERC20Upgradeable, IBondController, ITranche } from "../_interfaces/IPerpetualTranche.sol";
+
+import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import { MathUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/math/MathUpgradeable.sol";
+import { BondTranches, BondTranchesHelpers } from "./BondTranchesHelpers.sol";
+import { TrancheHelpers } from "./TrancheHelpers.sol";
+import { BondHelpers } from "./BondHelpers.sol";
+import { ERC20Helpers } from "./ERC20Helpers.sol";
+
+/**
+ *  @title TrancheManager
+ *
+ *  @notice Linked external library with helper functions for tranche management.
+ *
+ *  @dev Proxies which use external libraries are by default NOT upgrade safe.
+ *       We guarantee that this linked external library will never trigger selfdestruct,
+ *       and this one is.
+ *
+ */
+library TrancheManager {
+    // data handling
+    using BondHelpers for IBondController;
+    using TrancheHelpers for ITranche;
+    using BondTranchesHelpers for BondTranches;
+
+    // ERC20 operations
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+    using ERC20Helpers for IERC20Upgradeable;
+
+    // math
+    using MathUpgradeable for uint256;
+
+    //--------------------------------------------------------------------------
+    // Helper methods
+
+    /// @notice Low level method that redeems the given mature tranche for the underlying asset.
+    ///         It interacts with the button-wood bond contract.
+    function execMatureTrancheRedemption(IBondController bond, ITranche tranche, uint256 amount) external {
+        if (!bond.isMature()) {
+            bond.mature();
+        }
+        bond.redeemMature(address(tranche), amount);
+    }
+
+    /// @notice Low level method that redeems the given tranche for the underlying asset, before maturity.
+    ///         If the contract holds sibling tranches with proportional balances, those will also get redeemed.
+    ///         It interacts with the button-wood bond contract.
+    function execImmatureTrancheRedemption(IBondController bond, BondTranches memory bt) external {
+        uint256[] memory trancheAmts = bt.computeRedeemableTrancheAmounts(address(this));
+
+        // NOTE: It is guaranteed that if one tranche amount is zero, all amounts are zeros.
+        if (trancheAmts[0] > 0) {
+            bond.redeem(trancheAmts);
+        }
+    }
+
+    /// @notice Computes the value of the given amount of tranche tokens, based on it's current CDR.
+    ///         Value is denominated in the underlying collateral.
+    function computeTrancheValue(
+        address tranche,
+        address collateralToken,
+        uint256 trancheAmt
+    ) external view returns (uint256) {
+        (uint256 trancheClaim, uint256 trancheSupply) = ITranche(tranche).getTrancheCollateralization(
+            IERC20Upgradeable(collateralToken)
+        );
+        return trancheClaim.mulDiv(trancheAmt, trancheSupply, MathUpgradeable.Rounding.Up);
+    }
+}

--- a/spot-contracts/hardhat.config.ts
+++ b/spot-contracts/hardhat.config.ts
@@ -53,7 +53,7 @@ export default {
         settings: {
           optimizer: {
             enabled: true,
-            runs: 750,
+            runs: 200,
           },
         },
       },

--- a/spot-contracts/package.json
+++ b/spot-contracts/package.json
@@ -54,7 +54,7 @@
     "ethers": "^6.6.0",
     "ethers-v5": "npm:ethers@^5.7.0",
     "ganache-cli": "latest",
-    "hardhat": "^2.22.18",
+    "hardhat": "^2.22.19",
     "hardhat-gas-reporter": "latest",
     "lodash": "^4.17.21",
     "prettier": "^2.7.1",

--- a/spot-contracts/package.json
+++ b/spot-contracts/package.json
@@ -54,7 +54,7 @@
     "ethers": "^6.6.0",
     "ethers-v5": "npm:ethers@^5.7.0",
     "ganache-cli": "latest",
-    "hardhat": "^2.22.19",
+    "hardhat": "^2.23.0",
     "hardhat-gas-reporter": "latest",
     "lodash": "^4.17.21",
     "prettier": "^2.7.1",

--- a/spot-contracts/tasks/ops/vaults.ts
+++ b/spot-contracts/tasks/ops/vaults.ts
@@ -94,9 +94,9 @@ task("ops:vault:info")
     console.log("targetSubscriptionRatio:", hre.ethers.formatUnits(targetSubscriptionRatio, feeDecimals));
     console.log("targetDeviationRatio:", hre.ethers.formatUnits(feeOne, feeDecimals));
 
-    const drHardBounds = await feePolicy.drHardBounds();
-    console.log("deviationRatioBoundLower:", hre.ethers.formatUnits(drHardBounds.lower, feeDecimals));
-    console.log("deviationRatioBoundUpper:", hre.ethers.formatUnits(drHardBounds.upper, feeDecimals));
+    const drHardBound = await feePolicy.drHardBound();
+    console.log("deviationRatioBoundLower:", hre.ethers.formatUnits(drHardBound.lower, feeDecimals));
+    console.log("deviationRatioBoundUpper:", hre.ethers.formatUnits(drHardBound.upper, feeDecimals));
     console.log("deviationRatio:", hre.ethers.formatUnits(deviationRatio, feeDecimals));
 
     console.log("---------------------------------------------------------------");

--- a/spot-contracts/test/FeePolicy.ts
+++ b/spot-contracts/test/FeePolicy.ts
@@ -37,17 +37,17 @@ describe("FeePolicy", function () {
       expect(await feePolicy.vaultMintFeePerc()).to.eq(0n);
       expect(await feePolicy.vaultBurnFeePerc()).to.eq(0n);
 
-      const r = await feePolicy.perpRolloverFee();
-      expect(await r.minRolloverFeePerc).to.eq(toPerc("-0.07692307"));
-      expect(await r.perpDebasementSlope).to.eq(toPerc("0.07692307"));
-      expect(await r.perpEnrichmentSlope).to.eq(toPerc("0.07692307"));
-
       const fm = await feePolicy.flashMintFeePercs();
       expect(fm[0]).to.eq(toPerc("1"));
       expect(fm[1]).to.eq(toPerc("1"));
       const fr = await feePolicy.flashRedeemFeePercs();
       expect(fr[0]).to.eq(toPerc("1"));
       expect(fr[1]).to.eq(toPerc("1"));
+
+      expect(await feePolicy.debasementSystemTVLPerc()).to.eq(toPerc("0.001"));
+      expect(await feePolicy.enrichmentSystemTVLPerc()).to.eq(toPerc("0.0015015"));
+      expect(await feePolicy.debasementProtocolSharePerc()).to.eq(0n);
+      expect(await feePolicy.enrichmentProtocolSharePerc()).to.eq(0n);
     });
     it("should return owner", async function () {
       expect(await feePolicy.owner()).to.eq(await deployer.getAddress());
@@ -104,16 +104,16 @@ describe("FeePolicy", function () {
       it("should revert", async function () {
         await expect(
           feePolicy.connect(deployer).updateDRBounds([toPerc("0.9"), toPerc("2")], [toPerc("0.75"), toPerc("1.5")]),
-        ).to.be.revertedWithCustomError(feePolicy, "InvalidDRBounds");
+        ).to.be.revertedWithCustomError(feePolicy, "InvalidDRRange");
         await expect(
           feePolicy.connect(deployer).updateDRBounds([toPerc("0.5"), toPerc("2")], [toPerc("2"), toPerc("1.5")]),
-        ).to.be.revertedWithCustomError(feePolicy, "InvalidDRBounds");
+        ).to.be.revertedWithCustomError(feePolicy, "InvalidDRRange");
         await expect(
           feePolicy.connect(deployer).updateDRBounds([toPerc("0.5"), toPerc("2")], [toPerc("0.75"), toPerc("0.6")]),
-        ).to.be.revertedWithCustomError(feePolicy, "InvalidDRBounds");
+        ).to.be.revertedWithCustomError(feePolicy, "InvalidDRRange");
         await expect(
           feePolicy.connect(deployer).updateDRBounds([toPerc("0.5"), toPerc("2")], [toPerc("0.75"), toPerc("2.5")]),
-        ).to.be.revertedWithCustomError(feePolicy, "InvalidDRBounds");
+        ).to.be.revertedWithCustomError(feePolicy, "InvalidDRRange");
       });
     });
 
@@ -126,6 +126,39 @@ describe("FeePolicy", function () {
         const s2 = await feePolicy.drSoftBound();
         expect(s2[0]).to.eq(toPerc("0.75"));
         expect(s2[1]).to.eq(toPerc("1.5"));
+      });
+    });
+  });
+
+  describe("#updateRebalanceEquilibriumDR", function () {
+    describe("when triggered by non-owner", function () {
+      it("should revert", async function () {
+        await expect(
+          feePolicy.connect(otherUser).updateRebalanceEquilibriumDR([toPerc("1"), toPerc("1")]),
+        ).to.be.revertedWith("Ownable: caller is not the owner");
+      });
+    });
+
+    describe("when parameters are invalid", function () {
+      it("should revert", async function () {
+        await expect(
+          feePolicy.connect(deployer).updateRebalanceEquilibriumDR([toPerc("2"), toPerc("0.9")]),
+        ).to.be.revertedWithCustomError(feePolicy, "InvalidDRRange");
+        await expect(
+          feePolicy.connect(deployer).updateRebalanceEquilibriumDR([toPerc("1.1"), toPerc("2")]),
+        ).to.be.revertedWithCustomError(feePolicy, "InvalidDRRange");
+        await expect(
+          feePolicy.connect(deployer).updateRebalanceEquilibriumDR([toPerc("0.95"), toPerc("0.99")]),
+        ).to.be.revertedWithCustomError(feePolicy, "InvalidDRRange");
+      });
+    });
+
+    describe("when triggered by owner", function () {
+      it("should update dr hard bounds", async function () {
+        await feePolicy.connect(deployer).updateRebalanceEquilibriumDR([toPerc("0.5"), toPerc("2")]);
+        const s = await feePolicy.rebalEqDr();
+        expect(s[0]).to.eq(toPerc("0.5"));
+        expect(s[1]).to.eq(toPerc("2"));
       });
     });
   });
@@ -180,34 +213,6 @@ describe("FeePolicy", function () {
         expect(await feePolicy.computePerpBurnFeePerc()).to.eq("0");
         await feePolicy.connect(deployer).updatePerpBurnFees(toPerc("0.01"));
         expect(await feePolicy.computePerpBurnFeePerc()).to.eq(toPerc("0.01"));
-      });
-    });
-  });
-
-  describe("#updatePerpRolloverFees", function () {
-    describe("when triggered by non-owner", function () {
-      it("should revert", async function () {
-        await expect(
-          feePolicy.connect(otherUser).updatePerpRolloverFees({
-            minRolloverFeePerc: toPerc("-0.01"),
-            perpDebasementSlope: toPerc("0.01"),
-            perpEnrichmentSlope: toPerc("0.01"),
-          }),
-        ).to.be.revertedWith("Ownable: caller is not the owner");
-      });
-    });
-
-    describe("when triggered by owner", function () {
-      it("should update parameters", async function () {
-        await feePolicy.connect(deployer).updatePerpRolloverFees({
-          minRolloverFeePerc: toPerc("-0.01"),
-          perpDebasementSlope: toPerc("0.02"),
-          perpEnrichmentSlope: toPerc("0.03"),
-        });
-        const p = await feePolicy.perpRolloverFee();
-        expect(p.minRolloverFeePerc).to.eq(toPerc("-0.01"));
-        expect(p.perpDebasementSlope).to.eq(toPerc("0.02"));
-        expect(p.perpEnrichmentSlope).to.eq(toPerc("0.03"));
       });
     });
   });
@@ -308,15 +313,57 @@ describe("FeePolicy", function () {
     });
   });
 
+  describe("#updateRebalanceRates", function () {
+    describe("when triggered by non-owner", function () {
+      it("should revert", async function () {
+        await expect(
+          feePolicy.connect(otherUser).updateRebalanceRates(toPerc("0.005"), toPerc("0.01")),
+        ).to.be.revertedWith("Ownable: caller is not the owner");
+      });
+    });
+
+    describe("when triggered by owner", function () {
+      it("should update parameters", async function () {
+        await feePolicy.connect(deployer).updateRebalanceRates(toPerc("0.005"), toPerc("0.01"));
+        expect(await feePolicy.debasementSystemTVLPerc()).to.eq(toPerc("0.005"));
+        expect(await feePolicy.enrichmentSystemTVLPerc()).to.eq(toPerc("0.01"));
+      });
+    });
+  });
+
+  describe("#updateProtocolSharePerc", function () {
+    describe("when triggered by non-owner", function () {
+      it("should revert", async function () {
+        await expect(
+          feePolicy.connect(otherUser).updateProtocolSharePerc(toPerc("0.05"), toPerc("0.15")),
+        ).to.be.revertedWith("Ownable: caller is not the owner");
+      });
+    });
+
+    describe("when value is invalid", function () {
+      it("should update parameters", async function () {
+        await expect(
+          feePolicy.connect(deployer).updateProtocolSharePerc(0, toPerc("1.05")),
+        ).to.be.revertedWithCustomError(feePolicy, "InvalidPerc");
+        await expect(
+          feePolicy.connect(deployer).updateProtocolSharePerc(toPerc("1.05"), 0),
+        ).to.be.revertedWithCustomError(feePolicy, "InvalidPerc");
+      });
+    });
+
+    describe("when triggered by owner", function () {
+      it("should update parameters", async function () {
+        await feePolicy.connect(deployer).updateProtocolSharePerc(toPerc("0.05"), toPerc("0.15"));
+        expect(await feePolicy.debasementProtocolSharePerc()).to.eq(toPerc("0.05"));
+        expect(await feePolicy.enrichmentProtocolSharePerc()).to.eq(toPerc("0.15"));
+      });
+    });
+  });
+
   describe("fee logic", function () {
     beforeEach(async function () {
       await feePolicy.updatePerpMintFees(toPerc("0.025"));
       await feePolicy.updatePerpBurnFees(toPerc("0.035"));
-      await feePolicy.updatePerpRolloverFees({
-        minRolloverFeePerc: toPerc("-0.8"),
-        perpDebasementSlope: toPerc("1"),
-        perpEnrichmentSlope: toPerc("2"),
-      });
       await feePolicy.updateFlashFees([toPerc("0.1"), toPerc("0.2")], [toPerc("0.15"), toPerc("0.5")]);
       await feePolicy.updateVaultMintFees(toPerc("0.05"));
       await feePolicy.updateVaultBurnFees(toPerc("0.075"));
@@ -452,30 +499,6 @@ describe("FeePolicy", function () {
         });
       });
     });
-
-    describe("rollover fee", function () {
-      it("should compute fees as expected", async function () {
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("0"))).to.eq(toPerc("-0.8"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("0.01"))).to.eq(toPerc("-0.8"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("0.25"))).to.eq(toPerc("-0.75"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("0.5"))).to.eq(toPerc("-0.5"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("0.66"))).to.eq(toPerc("-0.34"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("0.7"))).to.eq(toPerc("-0.3"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("0.8"))).to.eq(toPerc("-0.2"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("0.9"))).to.eq(toPerc("-0.1"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("0.99"))).to.eq(toPerc("-0.01"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("1"))).to.eq("0");
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("1.01"))).to.eq(toPerc("0.02"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("1.05"))).to.eq(toPerc("0.1"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("1.1"))).to.eq(toPerc("0.2"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("1.25"))).to.eq(toPerc("0.5"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("1.5"))).to.eq(toPerc("1"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("1.75"))).to.eq(toPerc("1.5"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("2"))).to.eq(toPerc("2"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("5"))).to.eq(toPerc("8"));
-        expect(await feePolicy.computePerpRolloverFeePerc(toPerc("10"))).to.eq(toPerc("18"));
-      });
-    });
   });
 
   describe("#computeDeviationRatio", async function () {
@@ -514,6 +537,187 @@ describe("FeePolicy", function () {
         });
         expect(r).to.eq(toPerc("0.5"));
       });
+    });
+  });
+
+  describe("#computeRebalanceData", async function () {
+    beforeEach(async function () {
+      await feePolicy.updateTargetSubscriptionRatio(toPerc("1.25"));
+      await feePolicy.updateProtocolSharePerc(toPerc("0.05"), toPerc("0.1"));
+      await feePolicy.updateMaxRebalancePerc(toPerc("0.02"), toPerc("0.01"));
+      await feePolicy.updateRebalanceEquilibriumDR([toPerc("0.9999"), toPerc("1.0001")])
+    });
+
+    describe("when deviation is within eq range", function () {
+      it("should compute rebalance data", async function () {
+        await feePolicy.updateRebalanceEquilibriumDR([toPerc("0.5"), toPerc("2")])
+        const r1 = await feePolicy.computeRebalanceData({
+          perpTVL: toAmt("120"),
+          vaultTVL: toAmt("500"),
+          seniorTR: 200,
+        });
+        expect(r1[0]).to.eq(0n);
+        expect(r1[1]).to.eq(0n);
+        const r2 = await feePolicy.computeRebalanceData({
+          perpTVL: toAmt("80"),
+          vaultTVL: toAmt("500"),
+          seniorTR: 200,
+        });
+        expect(r2[0]).to.eq(0n);
+        expect(r2[1]).to.eq(0n);
+      });
+    });
+
+    describe("when deviation = 1.0", function () {
+      it("should compute rebalance data", async function () {
+        const r = await feePolicy.computeRebalanceData({
+          perpTVL: toAmt("100"),
+          vaultTVL: toAmt("500"),
+          seniorTR: 200,
+        });
+        expect(r[0]).to.eq(0n);
+        expect(r[1]).to.eq(0n);
+      });
+    });
+
+    describe("when deviation ~= 1.0", function () {
+      it("should compute rebalance data", async function () {
+        const r = await feePolicy.computeRebalanceData({
+          perpTVL: toAmt("100"),
+          vaultTVL: toAmt("500.001"),
+          seniorTR: 200,
+        });
+        expect(r[0]).to.eq(0n);
+        expect(r[1]).to.eq(0n);
+      });
+    });
+
+    describe("when deviation ~= 1.0", function () {
+      it("should compute rebalance data", async function () {
+        const r = await feePolicy.computeRebalanceData({
+          perpTVL: toAmt("99.999"),
+          vaultTVL: toAmt("500"),
+          seniorTR: 200,
+        });
+        expect(r[0]).to.eq(0n);
+        expect(r[1]).to.eq(0n);
+      });
+    });
+
+    describe("when deviation > 1.0", function () {
+      it("should compute rebalance data", async function () {
+        const r = await feePolicy.computeRebalanceData({
+          perpTVL: toAmt("100"),
+          vaultTVL: toAmt("1000"),
+          seniorTR: 200,
+        });
+        expect(r[0]).to.eq(toAmt("9.9"));
+        expect(r[1]).to.eq(toAmt("1.1"));
+      });
+    });
+
+    describe("when enrichment rate is very low", function () {
+      it("should compute rebalance data", async function () {
+        const r = await feePolicy.computeRebalanceData({
+          perpTVL: toAmt("100"),
+          vaultTVL: toAmt("500.09"),
+          seniorTR: 200,
+        });
+        expect(r[0]).to.eq(toAmt("0.01349639946"));
+        expect(r[1]).to.eq(toAmt("0.00149959994"));
+      });
+    });
+
+    describe("when deviation < 1.0", function () {
+      it("should compute rebalance data", async function () {
+        const r = await feePolicy.computeRebalanceData({
+          perpTVL: toAmt("1000"),
+          vaultTVL: toAmt("2500"),
+          seniorTR: 200,
+        });
+        expect(r[0]).to.eq(toAmt("-66.5"));
+        expect(r[1]).to.eq(toAmt("3.5"));
+      });
+    });
+
+    describe("when debasement rate is very low", function () {
+      it("should compute rebalance data", async function () {
+        const r = await feePolicy.computeRebalanceData({
+          perpTVL: toAmt("105"),
+          vaultTVL: toAmt("500"),
+          seniorTR: 200,
+        });
+        expect(r[0]).to.eq(toAmt("-3.958337165"));
+        expect(r[1]).to.eq(toAmt("0.208333535"));
+      });
+    });
+  });
+
+  describe("#computeDREquilibriumSplit", async function () {
+    it("should compute correct perp and vault underlying amounts", async function () {
+      const r = await feePolicy.computeDREquilibriumSplit(toFixedPtAmt("100"), 333);
+      expect(r[0]).to.eq(toFixedPtAmt("24.981245311327831957"));
+      expect(r[1]).to.eq(toFixedPtAmt("75.018754688672168043"));
+    });
+
+    it("should compute correct perp and vault underlying amounts", async function () {
+      await feePolicy.updateTargetSubscriptionRatio(toPercFixedPtAmt("1.0"));
+      const r = await feePolicy.computeDREquilibriumSplit(toFixedPtAmt("100"), 500);
+      expect(r[0]).to.eq(toFixedPtAmt("50"));
+      expect(r[1]).to.eq(toFixedPtAmt("50"));
+    });
+
+    it("should compute correct perp and vault underlying amounts", async function () {
+      await feePolicy.updateTargetSubscriptionRatio(toPercFixedPtAmt("2.0"));
+      const r = await feePolicy.computeDREquilibriumSplit(toFixedPtAmt("100"), 500);
+      expect(r[0]).to.eq(toFixedPtAmt("33.333333333333333333"));
+      expect(r[1]).to.eq(toFixedPtAmt("66.666666666666666667"));
+    });
+  });
+
+  describe("#computeDRNeutralSplit", async function () {
+    it("should compute proportional split", async function () {
+      const r = await feePolicy.computeDRNeutralSplit(
+        toFixedPtAmt("1000"),
+        toFixedPtAmt("100"),
+        toFixedPtAmt("1000"),
+        toFixedPtAmt("1000"),
+      );
+      expect(r[0]).to.equal(toFixedPtAmt("100"));
+      expect(r[1]).to.equal(toFixedPtAmt("100"));
+    });
+
+    it("should compute proportional split", async function () {
+      const r = await feePolicy.computeDRNeutralSplit(
+        toFixedPtAmt("1000"),
+        toFixedPtAmt("100"),
+        toFixedPtAmt("1000"),
+        toFixedPtAmt("100"),
+      );
+      expect(r[0]).to.equal(toFixedPtAmt("1000"));
+      expect(r[1]).to.equal(toFixedPtAmt("100"));
+    });
+
+    it("should compute proportional split", async function () {
+      const r = await feePolicy.computeDRNeutralSplit(
+        toFixedPtAmt("1000"),
+        toFixedPtAmt("100"),
+        toFixedPtAmt("100000"),
+        toFixedPtAmt("100"),
+      );
+      expect(r[0]).to.equal(toFixedPtAmt("1000"));
+      expect(r[1]).to.equal(toFixedPtAmt("1"));
+    });
+
+    it("should compute proportional split", async function () {
+      const r = await feePolicy.computeDRNeutralSplit(
+        toFixedPtAmt("1000"),
+        toFixedPtAmt("100"),
+        toFixedPtAmt("1000"),
+        toFixedPtAmt("10000"),
+      );
+      expect(r[0]).to.equal(toFixedPtAmt("10"));
+      expect(r[1]).to.equal(toFixedPtAmt("100"));
     });
   });
 });

--- a/spot-contracts/test/perp/PerpetualTranche_deposit.ts
+++ b/spot-contracts/test/perp/PerpetualTranche_deposit.ts
@@ -54,7 +54,6 @@ describe("PerpetualTranche", function () {
     await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
     await feePolicy.mockMethod("computePerpMintFeePerc()", [0]);
     await feePolicy.mockMethod("computePerpBurnFeePerc()", [0]);
-    await feePolicy.mockMethod("computePerpRolloverFeePerc(uint256)", [0]);
 
     const PerpetualTranche = await ethers.getContractFactory("PerpetualTranche");
     perp = await upgrades.deployProxy(
@@ -66,7 +65,14 @@ describe("PerpetualTranche", function () {
     );
     await advancePerpQueue(perp, 3600);
 
-    const vault = new DMock(await ethers.getContractFactory("RolloverVault"));
+    const TrancheManager = await ethers.getContractFactory("TrancheManager");
+    const trancheManager = await TrancheManager.deploy();
+    const RolloverVault = await ethers.getContractFactory("RolloverVault", {
+      libraries: {
+        TrancheManager: trancheManager.target,
+      },
+    });
+    const vault = new DMock(RolloverVault);
     await vault.deploy();
     await vault.mockMethod("getTVL()", [0]);
     await perp.updateVault(vault.target);

--- a/spot-contracts/test/perp/PerpetualTranche_deposit.ts
+++ b/spot-contracts/test/perp/PerpetualTranche_deposit.ts
@@ -494,6 +494,19 @@ describe("PerpetualTranche", function () {
         const r = await perp.computeMintAmt.staticCall(depositTrancheA.target, toFixedPtAmt("500"));
         expect(r).to.eq(toFixedPtAmt("495"));
       });
+
+      it("should update the total supply", async function () {
+        await perp.deposit(depositTrancheA.target, toFixedPtAmt("500"));
+        expect(await perp.totalSupply()).to.eq(toFixedPtAmt("500"));
+      });
+
+      it("should mint fees to the vault", async function () {
+        await expect(() => perp.deposit(depositTrancheA.target, toFixedPtAmt("500"))).to.changeTokenBalances(
+          perp,
+          [await perp.vault()],
+          [toFixedPtAmt("5")],
+        );
+      });
     });
 
     describe("when fee is set and caller is the vault", function () {

--- a/spot-contracts/test/perp/PerpetualTranche_redeem.ts
+++ b/spot-contracts/test/perp/PerpetualTranche_redeem.ts
@@ -616,11 +616,15 @@ describe("PerpetualTranche", function () {
 
       it("should update the total supply", async function () {
         await txFn();
-        expect(await perp.totalSupply()).to.eq(toFixedPtAmt("500"));
+        expect(await perp.totalSupply()).to.eq(toFixedPtAmt("550"));
       });
 
       it("should burn perp tokens", async function () {
         await expect(txFn).to.changeTokenBalances(perp, [deployer], [toFixedPtAmt("-500")]);
+      });
+
+      it("should transfer fees to the vault", async function () {
+        await expect(txFn).to.changeTokenBalances(perp, [await perp.vault()], [toFixedPtAmt("50")]);
       });
     });
 

--- a/spot-contracts/test/rollover-vault/RolloverVault_deposit_redeem.ts
+++ b/spot-contracts/test/rollover-vault/RolloverVault_deposit_redeem.ts
@@ -65,7 +65,7 @@ describe("RolloverVault", function () {
     await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
     await feePolicy.mockMethod("computePerpMintFeePerc()", [0]);
     await feePolicy.mockMethod("computePerpBurnFeePerc()", [0]);
-    await feePolicy.mockMethod("computePerpRolloverFeePerc(uint256)", [0]);
+
     await feePolicy.mockMethod("computeVaultMintFeePerc()", [0]);
     await feePolicy.mockMethod("computeVaultBurnFeePerc()", [0]);
     await feePolicy.mockMethod("computeUnderlyingToPerpVaultSwapFeePerc(uint256,uint256)", [0]);
@@ -83,8 +83,17 @@ describe("RolloverVault", function () {
     await perp.updateTolerableTrancheMaturity(1200, 4800);
     await advancePerpQueueToBondMaturity(perp, await getDepositBond(perp));
 
-    const RolloverVault = await ethers.getContractFactory("RolloverVault");
-    vault = await upgrades.deployProxy(RolloverVault.connect(deployer));
+    const TrancheManager = await ethers.getContractFactory("TrancheManager");
+    const trancheManager = await TrancheManager.deploy();
+    const RolloverVault = await ethers.getContractFactory("RolloverVault", {
+      libraries: {
+        TrancheManager: trancheManager.target,
+      },
+    });
+    await upgrades.silenceWarnings();
+    vault = await upgrades.deployProxy(RolloverVault.connect(deployer), {
+      unsafeAllow: ["external-library-linking"],
+    });
     await vault.init("RolloverVault", "VSHARE", perp.target, feePolicy.target);
     await perp.updateVault(vault.target);
 

--- a/spot-contracts/test/rollover-vault/RolloverVault_pair_ops.ts
+++ b/spot-contracts/test/rollover-vault/RolloverVault_pair_ops.ts
@@ -1,0 +1,587 @@
+import { expect } from "chai";
+import { network, ethers, upgrades } from "hardhat";
+import { Contract, Signer } from "ethers";
+
+import {
+  setupCollateralToken,
+  mintCollteralToken,
+  setupBondFactory,
+  depositIntoBond,
+  bondAt,
+  getTranches,
+  toFixedPtAmt,
+  toPercFixedPtAmt,
+  getDepositBond,
+  advancePerpQueue,
+  advancePerpQueueToBondMaturity,
+  checkPerpComposition,
+  checkVaultComposition,
+  DMock,
+} from "../helpers";
+
+let vault: Contract;
+let perp: Contract;
+let bondFactory: Contract;
+let collateralToken: Contract;
+let issuer: Contract;
+let feePolicy: Contract;
+let deployer: Signer;
+let reserveTranches: Contract[][] = [];
+let remainingJuniorTranches: Contract[][] = [];
+let currentBondIn: Contract;
+let currentTranchesIn: Contract[];
+
+describe("RolloverVault", function () {
+  beforeEach(async function () {
+    await network.provider.send("hardhat_reset");
+
+    const accounts = await ethers.getSigners();
+    deployer = accounts[0];
+
+    bondFactory = await setupBondFactory();
+    ({ collateralToken } = await setupCollateralToken("Bitcoin", "BTC"));
+
+    const BondIssuer = await ethers.getContractFactory("BondIssuer");
+    issuer = await upgrades.deployProxy(
+      BondIssuer.connect(deployer),
+      [bondFactory.target, collateralToken.target, 4800, [200, 800], 1200, 0],
+      {
+        initializer: "init(address,address,uint256,uint256[],uint256,uint256)",
+      },
+    );
+
+    feePolicy = new DMock(await ethers.getContractFactory("FeePolicy"));
+    await feePolicy.deploy();
+    await feePolicy.mockMethod("decimals()", [8]);
+    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
+    await feePolicy.mockMethod("computePerpMintFeePerc()", [0]);
+    await feePolicy.mockMethod("computePerpBurnFeePerc()", [0]);
+
+    await feePolicy.mockMethod("computeVaultMintFeePerc()", [0]);
+    await feePolicy.mockMethod("computeVaultBurnFeePerc()", [0]);
+    await feePolicy.mockMethod("computeUnderlyingToPerpVaultSwapFeePerc(uint256,uint256)", [0]);
+    await feePolicy.mockMethod("computePerpToUnderlyingVaultSwapFeePerc(uint256,uint256)", [0]);
+
+    const PerpetualTranche = await ethers.getContractFactory("PerpetualTranche");
+    perp = await upgrades.deployProxy(
+      PerpetualTranche.connect(deployer),
+      ["PerpetualTranche", "PERP", collateralToken.target, issuer.target, feePolicy.target],
+      {
+        initializer: "init(string,string,address,address,address)",
+      },
+    );
+    await perp.updateTolerableTrancheMaturity(1200, 4800);
+    await advancePerpQueueToBondMaturity(perp, await getDepositBond(perp));
+
+    const TrancheManager = await ethers.getContractFactory("TrancheManager");
+    const trancheManager = await TrancheManager.deploy();
+    const RolloverVault = await ethers.getContractFactory("RolloverVault", {
+      libraries: {
+        TrancheManager: trancheManager.target,
+      },
+    });
+    await upgrades.silenceWarnings();
+    vault = await upgrades.deployProxy(RolloverVault.connect(deployer), {
+      unsafeAllow: ["external-library-linking"],
+    });
+    await collateralToken.approve(vault.target, toFixedPtAmt("1"));
+    await vault.init("RolloverVault", "VSHARE", perp.target, feePolicy.target);
+    await perp.updateVault(vault.target);
+
+    reserveTranches = [];
+    remainingJuniorTranches = [];
+    for (let i = 0; i < 4; i++) {
+      const bond = await getDepositBond(perp);
+      const tranches = await getTranches(bond);
+      await depositIntoBond(bond, toFixedPtAmt("1200"), deployer);
+
+      await tranches[0].approve(perp.target, toFixedPtAmt("200"));
+      await perp.deposit(tranches[0].target, toFixedPtAmt("200"));
+
+      reserveTranches.push(tranches[0]);
+      remainingJuniorTranches.push(tranches[1]);
+      await advancePerpQueue(perp, 1200);
+    }
+
+    await checkPerpComposition(
+      perp,
+      [collateralToken, ...reserveTranches.slice(-3)],
+      [toFixedPtAmt("200"), toFixedPtAmt("200"), toFixedPtAmt("200"), toFixedPtAmt("200")],
+    );
+    await checkVaultComposition(vault, [collateralToken], [0]);
+    expect(await vault.assetCount()).to.eq(1);
+
+    await mintCollteralToken(collateralToken, toFixedPtAmt("100000"), deployer);
+    currentBondIn = await bondAt(await perp.getDepositBond.staticCall());
+    currentTranchesIn = await getTranches(currentBondIn);
+
+    await collateralToken.approve(vault.target, toFixedPtAmt("10000"));
+    await perp.approve(vault.target, toFixedPtAmt("10000"));
+
+    await vault.deposit(toFixedPtAmt("1000"));
+    await vault.deploy();
+    await vault.deposit(toFixedPtAmt("1000"));
+
+    await checkVaultComposition(
+      vault,
+      [collateralToken, currentTranchesIn[1]],
+      [toFixedPtAmt("1200"), toFixedPtAmt("800")],
+    );
+    expect(await vault.assetCount()).to.eq(2);
+  });
+
+  afterEach(async function () {
+    await network.provider.send("hardhat_reset");
+  });
+
+  describe("#mint2", function () {
+    describe("when dr = 1", function () {
+      beforeEach(async function () {
+        await feePolicy.mockMethod("computeDREquilibriumSplit(uint256,uint256)", [
+          toFixedPtAmt("25"),
+          toFixedPtAmt("75"),
+        ]);
+      });
+
+      it("should compute amounts", async function () {
+        const r = await vault.mint2.staticCall(toFixedPtAmt("100"));
+        expect(r[0]).to.eq(toFixedPtAmt("25"));
+        expect(r[1]).to.eq(toFixedPtAmt("75") * 1000000n);
+      });
+
+      it("should transfer underlying", async function () {
+        await expect(() => vault.mint2(toFixedPtAmt("100"))).to.changeTokenBalances(
+          collateralToken,
+          [deployer],
+          [toFixedPtAmt("-100")],
+        );
+      });
+
+      it("should mint perps", async function () {
+        await expect(() => vault.mint2(toFixedPtAmt("100"))).to.changeTokenBalances(
+          perp,
+          [deployer],
+          [toFixedPtAmt("25")],
+        );
+      });
+
+      it("should mint vault notes", async function () {
+        await expect(() => vault.mint2(toFixedPtAmt("100"))).to.changeTokenBalances(
+          vault,
+          [deployer],
+          [toFixedPtAmt("75") * 1000000n],
+        );
+      });
+
+      it("should increase tvl", async function () {
+        await vault.mint2(toFixedPtAmt("100"));
+        expect(await vault.getTVL.staticCall()).to.eq(toFixedPtAmt("2075"));
+        expect(await perp.getTVL.staticCall()).to.eq(toFixedPtAmt("825"));
+      });
+
+      it("should have the updated composition", async function () {
+        await vault.mint2(toFixedPtAmt("100"));
+        await checkPerpComposition(
+          perp,
+          [collateralToken, ...reserveTranches.slice(-3), currentTranchesIn[0]],
+          [toFixedPtAmt("0"), toFixedPtAmt("200"), toFixedPtAmt("200"), toFixedPtAmt("200"), toFixedPtAmt("225")],
+        );
+        await checkVaultComposition(
+          vault,
+          [collateralToken, currentTranchesIn[1]],
+          [toFixedPtAmt("1175"), toFixedPtAmt("900")],
+        );
+      });
+
+      it("should sync vault assets", async function () {
+        const tx = vault.mint2(toFixedPtAmt("100"));
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(collateralToken.target, toFixedPtAmt("1175"));
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(currentTranchesIn[1].target, toFixedPtAmt("900"));
+      });
+    });
+
+    describe("when dr > 1", function () {
+      beforeEach(async function () {
+        await feePolicy.mockMethod("computeDREquilibriumSplit(uint256,uint256)", [
+          toFixedPtAmt("25"),
+          toFixedPtAmt("75"),
+        ]);
+        await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1.25")]);
+        await vault.deposit(toFixedPtAmt("1000"));
+      });
+
+      it("should compute amounts", async function () {
+        const r = await vault.mint2.staticCall(toFixedPtAmt("100"));
+        expect(r[0]).to.eq(toFixedPtAmt("25"));
+        expect(r[1]).to.eq(toFixedPtAmt("75") * 1000000n);
+      });
+
+      it("should transfer underlying", async function () {
+        await expect(() => vault.mint2(toFixedPtAmt("100"))).to.changeTokenBalances(
+          collateralToken,
+          [deployer],
+          [toFixedPtAmt("-100")],
+        );
+      });
+
+      it("should mint perps", async function () {
+        await expect(() => vault.mint2(toFixedPtAmt("100"))).to.changeTokenBalances(
+          perp,
+          [deployer],
+          [toFixedPtAmt("25")],
+        );
+      });
+
+      it("should mint vault notes", async function () {
+        await expect(() => vault.mint2(toFixedPtAmt("100"))).to.changeTokenBalances(
+          vault,
+          [deployer],
+          [toFixedPtAmt("75") * 1000000n],
+        );
+      });
+
+      it("should increase tvl", async function () {
+        await vault.mint2(toFixedPtAmt("100"));
+        expect(await vault.getTVL.staticCall()).to.eq(toFixedPtAmt("3075"));
+        expect(await perp.getTVL.staticCall()).to.eq(toFixedPtAmt("825"));
+      });
+
+      it("should have the updated composition", async function () {
+        await vault.mint2(toFixedPtAmt("100"));
+        await checkPerpComposition(
+          perp,
+          [collateralToken, ...reserveTranches.slice(-3), currentTranchesIn[0]],
+          [toFixedPtAmt("0"), toFixedPtAmt("200"), toFixedPtAmt("200"), toFixedPtAmt("200"), toFixedPtAmt("225")],
+        );
+        await checkVaultComposition(
+          vault,
+          [collateralToken, currentTranchesIn[1]],
+          [toFixedPtAmt("2175"), toFixedPtAmt("900")],
+        );
+      });
+
+      it("should sync vault assets", async function () {
+        const tx = vault.mint2(toFixedPtAmt("100"));
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(collateralToken.target, toFixedPtAmt("2175"));
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(currentTranchesIn[1].target, toFixedPtAmt("900"));
+      });
+    });
+
+    describe("when dr < 1", function () {
+      beforeEach(async function () {
+        await feePolicy.mockMethod("computeDREquilibriumSplit(uint256,uint256)", [
+          toFixedPtAmt("25"),
+          toFixedPtAmt("75"),
+        ]);
+        await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("0.75")]);
+        await vault.redeem(toFixedPtAmt("500") * 1000000n);
+        expect(await vault.getTVL.staticCall()).to.eq(toFixedPtAmt("1500"));
+      });
+
+      it("should compute amounts", async function () {
+        const r = await vault.mint2.staticCall(toFixedPtAmt("100"));
+        expect(r[0]).to.eq(toFixedPtAmt("25"));
+        expect(r[1]).to.eq(toFixedPtAmt("75") * 1000000n);
+      });
+
+      it("should transfer underlying", async function () {
+        await expect(() => vault.mint2(toFixedPtAmt("100"))).to.changeTokenBalances(
+          collateralToken,
+          [deployer],
+          [toFixedPtAmt("-100")],
+        );
+      });
+
+      it("should mint perps", async function () {
+        await expect(() => vault.mint2(toFixedPtAmt("100"))).to.changeTokenBalances(
+          perp,
+          [deployer],
+          [toFixedPtAmt("25")],
+        );
+      });
+
+      it("should mint vault notes", async function () {
+        await expect(() => vault.mint2(toFixedPtAmt("100"))).to.changeTokenBalances(
+          vault,
+          [deployer],
+          [toFixedPtAmt("75") * 1000000n],
+        );
+      });
+
+      it("should increase tvl", async function () {
+        await vault.mint2(toFixedPtAmt("100"));
+        expect(await vault.getTVL.staticCall()).to.eq(toFixedPtAmt("1575"));
+        expect(await perp.getTVL.staticCall()).to.eq(toFixedPtAmt("825"));
+      });
+
+      it("should have the updated composition", async function () {
+        await vault.mint2(toFixedPtAmt("100"));
+        await checkPerpComposition(
+          perp,
+          [collateralToken, ...reserveTranches.slice(-3), currentTranchesIn[0]],
+          [toFixedPtAmt("0"), toFixedPtAmt("200"), toFixedPtAmt("200"), toFixedPtAmt("200"), toFixedPtAmt("225")],
+        );
+        await checkVaultComposition(
+          vault,
+          [collateralToken, currentTranchesIn[1]],
+          [toFixedPtAmt("875"), toFixedPtAmt("700")],
+        );
+      });
+
+      it("should sync vault assets", async function () {
+        const tx = vault.mint2(toFixedPtAmt("100"));
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(collateralToken.target, toFixedPtAmt("875"));
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(currentTranchesIn[1].target, toFixedPtAmt("700"));
+      });
+    });
+  });
+
+  describe("#redeem2", function () {
+    describe("when redeeming proportionally", function () {
+      beforeEach(async function () {
+        await feePolicy.mockMethod("computeDRNeutralSplit(uint256,uint256,uint256,uint256)", [
+          toFixedPtAmt("25"),
+          toFixedPtAmt("75") * 1000000n,
+        ]);
+      });
+
+      it("should compute amounts", async function () {
+        const r = await vault.redeem2.staticCall(toFixedPtAmt("25"), toFixedPtAmt("75") * 1000000n);
+
+        expect(r[0]).to.eq(toFixedPtAmt("25"));
+        expect(r[1]).to.eq(toFixedPtAmt("75") * 1000000n);
+
+        expect(r[2][0][0]).to.eq(collateralToken.target);
+        expect(r[2][0][1]).to.eq(toFixedPtAmt("45"));
+
+        expect(r[2][1][0]).to.eq(reserveTranches[3].target);
+        expect(r[2][1][1]).to.eq(toFixedPtAmt("6.25"));
+
+        expect(r[2][2][0]).to.eq(reserveTranches[1].target);
+        expect(r[2][2][1]).to.eq(toFixedPtAmt("6.25"));
+
+        expect(r[2][3][0]).to.eq(reserveTranches[2].target);
+        expect(r[2][3][1]).to.eq(toFixedPtAmt("6.25"));
+
+        expect(r[2][4][0]).to.eq(currentTranchesIn[0].target);
+        expect(r[2][4][1]).to.eq(toFixedPtAmt("6.25"));
+
+        expect(r[2][5][0]).to.eq(currentTranchesIn[1].target);
+        expect(r[2][5][1]).to.eq(toFixedPtAmt("30"));
+      });
+
+      it("should burn perps", async function () {
+        await expect(() => vault.redeem2(toFixedPtAmt("25"), toFixedPtAmt("75") * 1000000n)).to.changeTokenBalances(
+          perp,
+          [deployer],
+          [toFixedPtAmt("-25")],
+        );
+      });
+
+      it("should burn vault notes", async function () {
+        await expect(() => vault.redeem2(toFixedPtAmt("25"), toFixedPtAmt("75") * 1000000n)).to.changeTokenBalances(
+          vault,
+          [deployer],
+          [toFixedPtAmt("-75") * 1000000n],
+        );
+      });
+
+      it("should decrease tvl", async function () {
+        await vault.redeem2(toFixedPtAmt("25"), toFixedPtAmt("75") * 1000000n);
+        expect(await vault.getTVL.staticCall()).to.eq(toFixedPtAmt("1925"));
+        expect(await perp.getTVL.staticCall()).to.eq(toFixedPtAmt("775"));
+      });
+
+      it("should have the updated composition", async function () {
+        await vault.redeem2(toFixedPtAmt("25"), toFixedPtAmt("75") * 1000000n);
+        await checkPerpComposition(
+          perp,
+          [collateralToken, ...reserveTranches.slice(-3), currentTranchesIn[0]],
+          [
+            toFixedPtAmt("0"),
+            toFixedPtAmt("193.75"),
+            toFixedPtAmt("193.75"),
+            toFixedPtAmt("193.75"),
+            toFixedPtAmt("193.75"),
+          ],
+        );
+        await checkVaultComposition(
+          vault,
+          [collateralToken, currentTranchesIn[1]],
+          [toFixedPtAmt("1155"), toFixedPtAmt("770")],
+        );
+      });
+
+      it("should sync vault assets", async function () {
+        const tx = vault.redeem2(toFixedPtAmt("25"), toFixedPtAmt("75") * 1000000n);
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(collateralToken.target, toFixedPtAmt("1155"));
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(currentTranchesIn[1].target, toFixedPtAmt("770"));
+      });
+    });
+
+    describe("when redeeming more perps", function () {
+      beforeEach(async function () {
+        await feePolicy.mockMethod("computeDRNeutralSplit(uint256,uint256,uint256,uint256)", [
+          toFixedPtAmt("50"),
+          toFixedPtAmt("75") * 1000000n,
+        ]);
+        await collateralToken.transfer(perp.target, toFixedPtAmt("100"));
+      });
+
+      it("should compute amounts", async function () {
+        const r = await vault.redeem2.staticCall(toFixedPtAmt("100"), toFixedPtAmt("75") * 1000000n);
+
+        expect(r[0]).to.eq(toFixedPtAmt("50"));
+        expect(r[1]).to.eq(toFixedPtAmt("75") * 1000000n);
+
+        expect(r[2][0][0]).to.eq(collateralToken.target);
+        expect(r[2][0][1]).to.eq(toFixedPtAmt("51.25"));
+
+        expect(r[2][1][0]).to.eq(reserveTranches[3].target);
+        expect(r[2][1][1]).to.eq(toFixedPtAmt("12.5"));
+
+        expect(r[2][2][0]).to.eq(reserveTranches[1].target);
+        expect(r[2][2][1]).to.eq(toFixedPtAmt("12.5"));
+
+        expect(r[2][3][0]).to.eq(reserveTranches[2].target);
+        expect(r[2][3][1]).to.eq(toFixedPtAmt("12.5"));
+
+        expect(r[2][4][0]).to.eq(currentTranchesIn[0].target);
+        expect(r[2][4][1]).to.eq(toFixedPtAmt("12.5"));
+
+        expect(r[2][5][0]).to.eq(currentTranchesIn[1].target);
+        expect(r[2][5][1]).to.eq(toFixedPtAmt("30"));
+      });
+
+      it("should burn perps", async function () {
+        await expect(() => vault.redeem2(toFixedPtAmt("100"), toFixedPtAmt("75") * 1000000n)).to.changeTokenBalances(
+          perp,
+          [deployer],
+          [toFixedPtAmt("-50")],
+        );
+      });
+
+      it("should burn vault notes", async function () {
+        await expect(() => vault.redeem2(toFixedPtAmt("100"), toFixedPtAmt("75") * 1000000n)).to.changeTokenBalances(
+          vault,
+          [deployer],
+          [toFixedPtAmt("-75") * 1000000n],
+        );
+      });
+
+      it("should decrease tvl", async function () {
+        await vault.redeem2(toFixedPtAmt("100"), toFixedPtAmt("75") * 1000000n);
+        expect(await vault.getTVL.staticCall()).to.eq(toFixedPtAmt("1925"));
+        expect(await perp.getTVL.staticCall()).to.eq(toFixedPtAmt("843.75"));
+      });
+
+      it("should have the updated composition", async function () {
+        await vault.redeem2(toFixedPtAmt("100"), toFixedPtAmt("75") * 1000000n);
+        await checkPerpComposition(
+          perp,
+          [collateralToken, ...reserveTranches.slice(-3), currentTranchesIn[0]],
+          [
+            toFixedPtAmt("93.75"),
+            toFixedPtAmt("187.5"),
+            toFixedPtAmt("187.5"),
+            toFixedPtAmt("187.5"),
+            toFixedPtAmt("187.5"),
+          ],
+        );
+        await checkVaultComposition(
+          vault,
+          [collateralToken, currentTranchesIn[1]],
+          [toFixedPtAmt("1155"), toFixedPtAmt("770")],
+        );
+      });
+
+      it("should sync vault assets", async function () {
+        const tx = vault.redeem2(toFixedPtAmt("100"), toFixedPtAmt("75") * 1000000n);
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(collateralToken.target, toFixedPtAmt("1155"));
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(currentTranchesIn[1].target, toFixedPtAmt("770"));
+      });
+    });
+
+    describe("when redeeming more vault notes", function () {
+      beforeEach(async function () {
+        await feePolicy.mockMethod("computeDRNeutralSplit(uint256,uint256,uint256,uint256)", [
+          toFixedPtAmt("25"),
+          toFixedPtAmt("150") * 1000000n,
+        ]);
+      });
+
+      it("should compute amounts", async function () {
+        const r = await vault.redeem2.staticCall(toFixedPtAmt("25"), toFixedPtAmt("250") * 1000000n);
+
+        expect(r[0]).to.eq(toFixedPtAmt("25"));
+        expect(r[1]).to.eq(toFixedPtAmt("150") * 1000000n);
+
+        expect(r[2][0][0]).to.eq(collateralToken.target);
+        expect(r[2][0][1]).to.eq(toFixedPtAmt("90"));
+
+        expect(r[2][1][0]).to.eq(reserveTranches[3].target);
+        expect(r[2][1][1]).to.eq(toFixedPtAmt("6.25"));
+
+        expect(r[2][2][0]).to.eq(reserveTranches[1].target);
+        expect(r[2][2][1]).to.eq(toFixedPtAmt("6.25"));
+
+        expect(r[2][3][0]).to.eq(reserveTranches[2].target);
+        expect(r[2][3][1]).to.eq(toFixedPtAmt("6.25"));
+
+        expect(r[2][4][0]).to.eq(currentTranchesIn[0].target);
+        expect(r[2][4][1]).to.eq(toFixedPtAmt("6.25"));
+
+        expect(r[2][5][0]).to.eq(currentTranchesIn[1].target);
+        expect(r[2][5][1]).to.eq(toFixedPtAmt("60"));
+      });
+
+      it("should burn perps", async function () {
+        await expect(() => vault.redeem2(toFixedPtAmt("25"), toFixedPtAmt("250") * 1000000n)).to.changeTokenBalances(
+          perp,
+          [deployer],
+          [toFixedPtAmt("-25")],
+        );
+      });
+
+      it("should burn vault notes", async function () {
+        await expect(() => vault.redeem2(toFixedPtAmt("25"), toFixedPtAmt("250") * 1000000n)).to.changeTokenBalances(
+          vault,
+          [deployer],
+          [toFixedPtAmt("-150") * 1000000n],
+        );
+      });
+
+      it("should decrease tvl", async function () {
+        await vault.redeem2(toFixedPtAmt("25"), toFixedPtAmt("250") * 1000000n);
+        expect(await vault.getTVL.staticCall()).to.eq(toFixedPtAmt("1850"));
+        expect(await perp.getTVL.staticCall()).to.eq(toFixedPtAmt("775"));
+      });
+
+      it("should have the updated composition", async function () {
+        await vault.redeem2(toFixedPtAmt("25"), toFixedPtAmt("250") * 1000000n);
+        await checkPerpComposition(
+          perp,
+          [collateralToken, ...reserveTranches.slice(-3), currentTranchesIn[0]],
+          [
+            toFixedPtAmt("0"),
+            toFixedPtAmt("193.75"),
+            toFixedPtAmt("193.75"),
+            toFixedPtAmt("193.75"),
+            toFixedPtAmt("193.75"),
+          ],
+        );
+        await checkVaultComposition(
+          vault,
+          [collateralToken, currentTranchesIn[1]],
+          [toFixedPtAmt("1110"), toFixedPtAmt("740")],
+        );
+      });
+
+      it("should sync vault assets", async function () {
+        const tx = vault.redeem2(toFixedPtAmt("25"), toFixedPtAmt("250") * 1000000n);
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(collateralToken.target, toFixedPtAmt("1110"));
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(currentTranchesIn[1].target, toFixedPtAmt("740"));
+      });
+    });
+  });
+});

--- a/spot-contracts/test/rollover-vault/RolloverVault_rebalance.ts
+++ b/spot-contracts/test/rollover-vault/RolloverVault_rebalance.ts
@@ -1,0 +1,294 @@
+import { expect } from "chai";
+import { network, ethers, upgrades } from "hardhat";
+import { Contract, Signer } from "ethers";
+
+import {
+  setupCollateralToken,
+  mintCollteralToken,
+  setupBondFactory,
+  depositIntoBond,
+  bondAt,
+  getTranches,
+  toFixedPtAmt,
+  getDepositBond,
+  advancePerpQueue,
+  advancePerpQueueToBondMaturity,
+  checkPerpComposition,
+  checkVaultComposition,
+  DMock,
+  toPercFixedPtAmt,
+  TimeHelpers,
+} from "../helpers";
+
+let vault: Contract;
+let perp: Contract;
+let bondFactory: Contract;
+let collateralToken: Contract;
+let issuer: Contract;
+let feePolicy: Contract;
+let deployer: Signer;
+const reserveSrTranches: Contract[][] = [];
+const reserveJrTranches: Contract[][] = [];
+
+describe("RolloverVault", function () {
+  beforeEach(async function () {
+    await network.provider.send("hardhat_reset");
+
+    const accounts = await ethers.getSigners();
+    deployer = accounts[0];
+
+    bondFactory = await setupBondFactory();
+    ({ collateralToken } = await setupCollateralToken("Bitcoin", "BTC"));
+
+    const BondIssuer = await ethers.getContractFactory("BondIssuer");
+    issuer = await upgrades.deployProxy(
+      BondIssuer.connect(deployer),
+      [bondFactory.target, collateralToken.target, 4 * 86400, [200, 800], 86400, 0],
+      {
+        initializer: "init(address,address,uint256,uint256[],uint256,uint256)",
+      },
+    );
+
+    feePolicy = new DMock(await ethers.getContractFactory("FeePolicy"));
+    await feePolicy.deploy();
+    await feePolicy.mockMethod("decimals()", [8]);
+    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
+    await feePolicy.mockMethod("computePerpMintFeePerc()", [0]);
+    await feePolicy.mockMethod("computePerpBurnFeePerc()", [0]);
+
+    await feePolicy.mockMethod("computeVaultMintFeePerc()", [0]);
+    await feePolicy.mockMethod("computeVaultBurnFeePerc()", [0]);
+    await feePolicy.mockMethod("computeUnderlyingToPerpVaultSwapFeePerc(uint256,uint256)", [0]);
+    await feePolicy.mockMethod("computePerpToUnderlyingVaultSwapFeePerc(uint256,uint256)", [0]);
+
+    const PerpetualTranche = await ethers.getContractFactory("PerpetualTranche");
+    perp = await upgrades.deployProxy(
+      PerpetualTranche.connect(deployer),
+      ["PerpetualTranche", "PERP", collateralToken.target, issuer.target, feePolicy.target],
+      {
+        initializer: "init(string,string,address,address,address)",
+      },
+    );
+
+    await perp.updateTolerableTrancheMaturity(86400, 4 * 86400);
+    await advancePerpQueueToBondMaturity(perp, await getDepositBond(perp));
+
+    const TrancheManager = await ethers.getContractFactory("TrancheManager");
+    const trancheManager = await TrancheManager.deploy();
+    const RolloverVault = await ethers.getContractFactory("RolloverVault", {
+      libraries: {
+        TrancheManager: trancheManager.target,
+      },
+    });
+    await upgrades.silenceWarnings();
+    vault = await upgrades.deployProxy(RolloverVault.connect(deployer), {
+      unsafeAllow: ["external-library-linking"],
+    });
+    await vault.init("RolloverVault", "VSHARE", perp.target, feePolicy.target);
+    await perp.updateVault(vault.target);
+
+    for (let i = 0; i < 4; i++) {
+      const bond = await getDepositBond(perp);
+      const tranches = await getTranches(bond);
+      await depositIntoBond(bond, toFixedPtAmt("1000"), deployer);
+
+      await tranches[0].approve(perp.target, toFixedPtAmt("200"));
+      await perp.deposit(tranches[0].target, toFixedPtAmt("200"));
+
+      reserveSrTranches.push(tranches[0]);
+      reserveJrTranches.push(tranches[1]);
+      await advancePerpQueue(perp, 86400);
+    }
+
+    await checkPerpComposition(
+      perp,
+      [collateralToken, ...reserveSrTranches.slice(-3)],
+      [toFixedPtAmt("200"), toFixedPtAmt("200"), toFixedPtAmt("200"), toFixedPtAmt("200")],
+    );
+
+    await mintCollteralToken(collateralToken, toFixedPtAmt("100000"), deployer);
+    await collateralToken.approve(vault.target, toFixedPtAmt("100000"));
+    const currentBondIn = await bondAt(await perp.getDepositBond.staticCall());
+    const currentTranchesIn = await getTranches(currentBondIn);
+    await vault.deposit(toFixedPtAmt("2000"));
+    await vault.deploy();
+
+    await checkVaultComposition(
+      vault,
+      [collateralToken, reserveSrTranches[1], currentTranchesIn[1]],
+      [toFixedPtAmt("200"), toFixedPtAmt("200"), toFixedPtAmt("1600")],
+    );
+    expect(await vault.assetCount()).to.eq(3);
+    await TimeHelpers.increaseTime(86401);
+
+    await feePolicy.mockMethod("computeRebalanceData((uint256,uint256,uint256))", [[0n, 0n]]);
+  });
+
+  afterEach(async function () {
+    await network.provider.send("hardhat_reset");
+  });
+
+  describe("#rebalance()", function () {
+    describe("when system is paused", function () {
+      it("should revert", async function () {
+        await vault.pause();
+        await expect(vault.rebalance()).to.be.revertedWith("Pausable: paused");
+      });
+    });
+
+    describe("when rebalance is paused", function () {
+      it("should revert", async function () {
+        await vault.pauseRebalance();
+        await expect(vault.rebalance()).to.be.revertedWithCustomError(vault, "LastRebalanceTooRecent");
+      });
+    });
+
+    describe("when invoked too soon", function () {
+      it("should revert", async function () {
+        await vault.rebalance();
+        await expect(vault.rebalance()).to.be.revertedWithCustomError(vault, "LastRebalanceTooRecent");
+        await TimeHelpers.increaseTime(86401);
+        await expect(vault.rebalance()).to.not.be.reverted;
+      });
+    });
+
+    describe("perp debasement", function () {
+      beforeEach(async function () {
+        await feePolicy.mockMethod("computeRebalanceData((uint256,uint256,uint256))", [[toFixedPtAmt("-10"), 0n]]);
+      });
+      it("should transfer value to the vault (by minting and melding perps)", async function () {
+        expect(await perp.totalSupply()).to.eq(toFixedPtAmt("800"));
+        expect(await perp.getTVL.staticCall()).to.eq(toFixedPtAmt("800"));
+        expect(await vault.getTVL.staticCall()).to.eq(toFixedPtAmt("2000"));
+        await expect(() => vault.rebalance()).to.changeTokenBalances(perp, [vault], [toFixedPtAmt("0")]);
+        expect(await perp.getTVL.staticCall()).to.eq(toFixedPtAmt("790.123456790123456792"));
+        expect(await vault.getTVL.staticCall()).to.eq(toFixedPtAmt("2009.876543209876543204"));
+        expect(await perp.totalSupply()).to.eq(toFixedPtAmt("800"));
+      });
+      it("should update the vault balance (after melding)", async function () {
+        await expect(() => vault.rebalance()).to.changeTokenBalances(
+          collateralToken,
+          [vault],
+          [toFixedPtAmt("24.691358024691358")],
+        );
+      });
+      it("should sync token balances", async function () {
+        const tx = vault.rebalance();
+        await expect(tx)
+          .to.emit(vault, "AssetSynced")
+          .withArgs(collateralToken.target, toFixedPtAmt("224.691358024691358"));
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(perp.target, toFixedPtAmt("0"));
+      });
+    });
+
+    describe("perp debasement with protocol fee", function () {
+      beforeEach(async function () {
+        await feePolicy.mockMethod("computeRebalanceData((uint256,uint256,uint256))", [
+          [toFixedPtAmt("-9"), toFixedPtAmt("1")],
+        ]);
+      });
+      it("should transfer value to the vault (by minting and melding perps)", async function () {
+        expect(await perp.totalSupply()).to.eq(toFixedPtAmt("800"));
+        expect(await perp.getTVL.staticCall()).to.eq(toFixedPtAmt("800"));
+        expect(await vault.getTVL.staticCall()).to.eq(toFixedPtAmt("2000"));
+        await expect(() => vault.rebalance()).to.changeTokenBalances(perp, [vault], [toFixedPtAmt("0")]);
+        expect(await perp.getTVL.staticCall()).to.eq(toFixedPtAmt("790.123456790123456792"));
+        expect(await vault.getTVL.staticCall()).to.eq(toFixedPtAmt("2008.876543209876543204"));
+        expect(await perp.totalSupply()).to.eq(toFixedPtAmt("800"));
+      });
+      it("should pay the protocol fee", async function () {
+        await expect(() => vault.rebalance()).to.changeTokenBalances(collateralToken, [deployer], [toFixedPtAmt("1")]);
+      });
+      it("should update the vault balance (after melding)", async function () {
+        await expect(() => vault.rebalance()).to.changeTokenBalances(
+          collateralToken,
+          [vault],
+          [toFixedPtAmt("23.691358024691358")],
+        );
+      });
+      it("should sync token balances", async function () {
+        const tx = vault.rebalance();
+        await expect(tx)
+          .to.emit(vault, "AssetSynced")
+          .withArgs(collateralToken.target, toFixedPtAmt("223.691358024691358"));
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(perp.target, toFixedPtAmt("0"));
+      });
+    });
+
+    describe("perp enrichment", function () {
+      let depositBond: Contract, depositTranches: Contract[];
+      beforeEach(async function () {
+        await feePolicy.mockMethod("computeRebalanceData((uint256,uint256,uint256))", [[toFixedPtAmt("25"), 0n]]);
+        await perp.updateState();
+        depositBond = await getDepositBond(perp);
+        depositTranches = await getTranches(depositBond);
+      });
+      it("should tranche using deposit bond", async function () {
+        await expect(() => vault.rebalance()).to.changeTokenBalances(
+          collateralToken,
+          [vault, depositBond.target],
+          [toFixedPtAmt("-125"), toFixedPtAmt("125")],
+        );
+      });
+      it("should transfer seniors from vault to perp", async function () {
+        await expect(() => vault.rebalance()).to.changeTokenBalances(
+          depositTranches[0],
+          [vault, perp],
+          [toFixedPtAmt("0"), toFixedPtAmt("25")],
+        );
+      });
+      it("should not change perp supply", async function () {
+        expect(await perp.totalSupply()).to.eq(toFixedPtAmt("800"));
+        await vault.rebalance();
+        expect(await perp.totalSupply()).to.eq(toFixedPtAmt("800"));
+      });
+      it("should sync token balances", async function () {
+        const tx = vault.rebalance();
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(collateralToken.target, toFixedPtAmt("75"));
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(depositTranches[1].target, toFixedPtAmt("100"));
+        await expect(tx).to.emit(perp, "ReserveSynced").withArgs(depositTranches[0].target, toFixedPtAmt("25"));
+      });
+    });
+
+    describe("perp enrichment with protocol fee", function () {
+      let depositBond: Contract, depositTranches: Contract[];
+      beforeEach(async function () {
+        await feePolicy.mockMethod("computeRebalanceData((uint256,uint256,uint256))", [
+          [toFixedPtAmt("20"), toFixedPtAmt("5")],
+        ]);
+        await perp.updateState();
+        depositBond = await getDepositBond(perp);
+        depositTranches = await getTranches(depositBond);
+      });
+
+      it("should tranche using deposit bond", async function () {
+        await expect(() => vault.rebalance()).to.changeTokenBalances(
+          collateralToken,
+          [vault, depositBond.target],
+          [toFixedPtAmt("-105"), toFixedPtAmt("100")],
+        );
+      });
+      it("should transfer seniors from vault to perp", async function () {
+        await expect(() => vault.rebalance()).to.changeTokenBalances(
+          depositTranches[0],
+          [vault, perp],
+          [toFixedPtAmt("0"), toFixedPtAmt("20")],
+        );
+      });
+      it("should pay the protocol fee", async function () {
+        await expect(() => vault.rebalance()).to.changeTokenBalances(collateralToken, [deployer], [toFixedPtAmt("5")]);
+      });
+      it("should not change perp supply", async function () {
+        expect(await perp.totalSupply()).to.eq(toFixedPtAmt("800"));
+        await vault.rebalance();
+        expect(await perp.totalSupply()).to.eq(toFixedPtAmt("800"));
+      });
+      it("should sync token balances", async function () {
+        const tx = vault.rebalance();
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(collateralToken.target, toFixedPtAmt("95"));
+        await expect(tx).to.emit(vault, "AssetSynced").withArgs(depositTranches[1].target, toFixedPtAmt("80"));
+        await expect(tx).to.emit(perp, "ReserveSynced").withArgs(depositTranches[0].target, toFixedPtAmt("20"));
+      });
+    });
+  });
+});

--- a/spot-contracts/test/rollover-vault/RolloverVault_swap.ts
+++ b/spot-contracts/test/rollover-vault/RolloverVault_swap.ts
@@ -58,7 +58,7 @@ describe("RolloverVault", function () {
     await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
     await feePolicy.mockMethod("computePerpMintFeePerc()", [0]);
     await feePolicy.mockMethod("computePerpBurnFeePerc()", [0]);
-    await feePolicy.mockMethod("computePerpRolloverFeePerc(uint256)", [0]);
+
     await feePolicy.mockMethod("computeVaultMintFeePerc()", [0]);
     await feePolicy.mockMethod("computeVaultBurnFeePerc()", [0]);
     await feePolicy.mockMethod("computeUnderlyingToPerpVaultSwapFeePerc(uint256,uint256)", [0]);
@@ -75,8 +75,17 @@ describe("RolloverVault", function () {
     await perp.updateTolerableTrancheMaturity(1200, 4800);
     await advancePerpQueueToBondMaturity(perp, await getDepositBond(perp));
 
-    const RolloverVault = await ethers.getContractFactory("RolloverVault");
-    vault = await upgrades.deployProxy(RolloverVault.connect(deployer));
+    const TrancheManager = await ethers.getContractFactory("TrancheManager");
+    const trancheManager = await TrancheManager.deploy();
+    const RolloverVault = await ethers.getContractFactory("RolloverVault", {
+      libraries: {
+        TrancheManager: trancheManager.target,
+      },
+    });
+    await upgrades.silenceWarnings();
+    vault = await upgrades.deployProxy(RolloverVault.connect(deployer), {
+      unsafeAllow: ["external-library-linking"],
+    });
     await collateralToken.approve(vault.target, toFixedPtAmt("1"));
     await vault.init("RolloverVault", "VSHARE", perp.target, feePolicy.target);
     await perp.updateVault(vault.target);

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,7 +59,7 @@ __metadata:
     ethers: ^6.6.0
     ethers-v5: "npm:ethers@^5.7.0"
     ganache-cli: latest
-    hardhat: ^2.22.18
+    hardhat: ^2.22.19
     hardhat-gas-reporter: latest
     lodash: ^4.17.21
     prettier: ^2.7.1
@@ -1202,10 +1202,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nomicfoundation/edr-darwin-arm64@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@nomicfoundation/edr-darwin-arm64@npm:0.8.0"
+  checksum: efae7cf00c6c18e9b3854d8bf3fbb4b1e3932279f83fabb82ddfd74d623886d3cf6b00d4c437b5e81e51d16d02a5759f5a27dae25e0d64eec33422df43251d16
+  languageName: node
+  linkType: hard
+
 "@nomicfoundation/edr-darwin-x64@npm:0.7.0":
   version: 0.7.0
   resolution: "@nomicfoundation/edr-darwin-x64@npm:0.7.0"
   checksum: 4b7cbbe6e6b0484805814ca7f2151de780dfc6102d443126666a4e5a19955343cb6e709c0f99b3a80b0b07fce50d5c2cee9958c516a1c2b0f2ac568a30db1712
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-darwin-x64@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@nomicfoundation/edr-darwin-x64@npm:0.8.0"
+  checksum: fdc298850dd83e4c6e9ca42b87de112dfd38a369b4f8d7b2fbeca6e6e3f1d24879bc6e57e2362eb173525c26bd9456621c95fd4209feb1d17e3b724d8d9ed232
   languageName: node
   linkType: hard
 
@@ -1216,10 +1230,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nomicfoundation/edr-linux-arm64-gnu@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@nomicfoundation/edr-linux-arm64-gnu@npm:0.8.0"
+  checksum: f1df885d79e7887a7fb67b17e1e2337d7eba65c415942d21f1ca1118265597ba9caec409a3ff226b96a8d2facb7bfc1e1fc1338f831e793621afa25a9e3d78ad
+  languageName: node
+  linkType: hard
+
 "@nomicfoundation/edr-linux-arm64-musl@npm:0.7.0":
   version: 0.7.0
   resolution: "@nomicfoundation/edr-linux-arm64-musl@npm:0.7.0"
   checksum: 005faee82c11965430a72eaa8a55d87db0ea8b149b6d0f483b505e099152c7148a959412c387e143efc0fd51fb2221dae4e1d7004c83a9f323819db1049713f7
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-linux-arm64-musl@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@nomicfoundation/edr-linux-arm64-musl@npm:0.8.0"
+  checksum: aa5de26be9d44b9e0e0538e1a5110aa173932cb9a21ab6c60deabe9499399f775cad02353f05ae7b8883fa59af6dd92e0f7a268fb7518736f3134a5d66d8f71c
   languageName: node
   linkType: hard
 
@@ -1230,6 +1258,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nomicfoundation/edr-linux-x64-gnu@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@nomicfoundation/edr-linux-x64-gnu@npm:0.8.0"
+  checksum: 0eeda6028fa923a8bd2b46ae65344e7244a4b06817fdb509349802cb80c0a81c7751d2727e71cb780474453d74e9f286807e7efc714db22205c47d3f676d6bb4
+  languageName: node
+  linkType: hard
+
 "@nomicfoundation/edr-linux-x64-musl@npm:0.7.0":
   version: 0.7.0
   resolution: "@nomicfoundation/edr-linux-x64-musl@npm:0.7.0"
@@ -1237,10 +1272,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nomicfoundation/edr-linux-x64-musl@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@nomicfoundation/edr-linux-x64-musl@npm:0.8.0"
+  checksum: 87d8d3522f36b4b6023a05c53f7d33748afb432659cafb4e255dc012613757cc3f70687693d080c65ecf8d73092534d4a00959b9d69e9d596dbce230f2e76e87
+  languageName: node
+  linkType: hard
+
 "@nomicfoundation/edr-win32-x64-msvc@npm:0.7.0":
   version: 0.7.0
   resolution: "@nomicfoundation/edr-win32-x64-msvc@npm:0.7.0"
   checksum: 9f070a202cecab2d1f28353e5d90cd113ef98b9473169c83b97ab140898bd47a301a0cae69733346fe4cc57c31aa6f3796ab3280f1316aa79d561fecd00cc222
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr-win32-x64-msvc@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@nomicfoundation/edr-win32-x64-msvc@npm:0.8.0"
+  checksum: 764dbf36654aa377d4b33e751b3cb98381f5dad1124cce0acdc4a0cbc247fe1b51f163ec3b293009937c398cce482bd492d21e00383acbc201c25380f53bb87d
   languageName: node
   linkType: hard
 
@@ -1256,6 +1305,21 @@ __metadata:
     "@nomicfoundation/edr-linux-x64-musl": 0.7.0
     "@nomicfoundation/edr-win32-x64-msvc": 0.7.0
   checksum: 83c54e2e2815c57ce56262f1010a0c5a2917b366bcf0acfad7662cbf2ccf46fd281e66c6db67bca9db7d91f699254216708045e882fda08c81361f111a07cb48
+  languageName: node
+  linkType: hard
+
+"@nomicfoundation/edr@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@nomicfoundation/edr@npm:0.8.0"
+  dependencies:
+    "@nomicfoundation/edr-darwin-arm64": 0.8.0
+    "@nomicfoundation/edr-darwin-x64": 0.8.0
+    "@nomicfoundation/edr-linux-arm64-gnu": 0.8.0
+    "@nomicfoundation/edr-linux-arm64-musl": 0.8.0
+    "@nomicfoundation/edr-linux-x64-gnu": 0.8.0
+    "@nomicfoundation/edr-linux-x64-musl": 0.8.0
+    "@nomicfoundation/edr-win32-x64-msvc": 0.8.0
+  checksum: eeabb9f62174e1742d08d31904ae879c7c05de89f929980df2fa9dec5763528f3b8965bedca93fe7d1d4adb9e56c56a9dc8096992cf6f10b907d3f32f04c6676
   languageName: node
   linkType: hard
 
@@ -6426,6 +6490,68 @@ __metadata:
   bin:
     hardhat: internal/cli/bootstrap.js
   checksum: e350e80a96846a465e1ca0c92a30a83e5a04225b8def19c9703d049f4a05ac69ff12150f93bf647e3ce3f82e2264558c6a2cec1b8e8a8494b97ffbf241f54077
+  languageName: node
+  linkType: hard
+
+"hardhat@npm:^2.22.19":
+  version: 2.22.19
+  resolution: "hardhat@npm:2.22.19"
+  dependencies:
+    "@ethersproject/abi": ^5.1.2
+    "@metamask/eth-sig-util": ^4.0.0
+    "@nomicfoundation/edr": ^0.8.0
+    "@nomicfoundation/ethereumjs-common": 4.0.4
+    "@nomicfoundation/ethereumjs-tx": 5.0.4
+    "@nomicfoundation/ethereumjs-util": 9.0.4
+    "@nomicfoundation/solidity-analyzer": ^0.1.0
+    "@sentry/node": ^5.18.1
+    "@types/bn.js": ^5.1.0
+    "@types/lru-cache": ^5.1.0
+    adm-zip: ^0.4.16
+    aggregate-error: ^3.0.0
+    ansi-escapes: ^4.3.0
+    boxen: ^5.1.2
+    chokidar: ^4.0.0
+    ci-info: ^2.0.0
+    debug: ^4.1.1
+    enquirer: ^2.3.0
+    env-paths: ^2.2.0
+    ethereum-cryptography: ^1.0.3
+    ethereumjs-abi: ^0.6.8
+    find-up: ^5.0.0
+    fp-ts: 1.19.3
+    fs-extra: ^7.0.1
+    immutable: ^4.0.0-rc.12
+    io-ts: 1.10.4
+    json-stream-stringify: ^3.1.4
+    keccak: ^3.0.2
+    lodash: ^4.17.11
+    mnemonist: ^0.38.0
+    mocha: ^10.0.0
+    p-map: ^4.0.0
+    picocolors: ^1.1.0
+    raw-body: ^2.4.1
+    resolve: 1.17.0
+    semver: ^6.3.0
+    solc: 0.8.26
+    source-map-support: ^0.5.13
+    stacktrace-parser: ^0.1.10
+    tinyglobby: ^0.2.6
+    tsort: 0.0.1
+    undici: ^5.14.0
+    uuid: ^8.3.2
+    ws: ^7.4.6
+  peerDependencies:
+    ts-node: "*"
+    typescript: "*"
+  peerDependenciesMeta:
+    ts-node:
+      optional: true
+    typescript:
+      optional: true
+  bin:
+    hardhat: internal/cli/bootstrap.js
+  checksum: 08b6c1912528ed3c013d731a312836e22ad5bdbbce27a78f8dc395154548f723c6b13af90dcee71401bfd1ee910005ab252aafb44cc5e42daaee8a41e5b4c739
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,7 +59,7 @@ __metadata:
     ethers: ^6.6.0
     ethers-v5: "npm:ethers@^5.7.0"
     ganache-cli: latest
-    hardhat: ^2.22.19
+    hardhat: ^2.23.0
     hardhat-gas-reporter: latest
     lodash: ^4.17.21
     prettier: ^2.7.1
@@ -435,6 +435,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethereumjs/rlp@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "@ethereumjs/rlp@npm:5.0.2"
+  bin:
+    rlp: bin/rlp.cjs
+  checksum: b569061ddb1f4cf56a82f7a677c735ba37f9e94e2bbaf567404beb9e2da7aa1f595e72fc12a17c61f7aec67fd5448443efe542967c685a2fe0ffc435793dcbab
+  languageName: node
+  linkType: hard
+
 "@ethereumjs/tx@npm:3.4.0":
   version: 3.4.0
   resolution: "@ethereumjs/tx@npm:3.4.0"
@@ -463,6 +472,16 @@ __metadata:
     ethereum-cryptography: ^2.0.0
     micro-ftch: ^0.3.1
   checksum: 9ae5dee8f12b0faf81cd83f06a41560e79b0ba96a48262771d897a510ecae605eb6d84f687da001ab8ccffd50f612ae50f988ef76e6312c752897f462f3ac08d
+  languageName: node
+  linkType: hard
+
+"@ethereumjs/util@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "@ethereumjs/util@npm:9.1.0"
+  dependencies:
+    "@ethereumjs/rlp": ^5.0.2
+    ethereum-cryptography: ^2.2.1
+  checksum: 594e009c3001ca1ca658b4ded01b38e72f5dd5dd76389efd90cb020de099176a3327685557df268161ac3144333cfe8abaae68cda8ae035d9cc82409d386d79a
   languageName: node
   linkType: hard
 
@@ -1133,6 +1152,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/curves@npm:~1.8.1":
+  version: 1.8.1
+  resolution: "@noble/curves@npm:1.8.1"
+  dependencies:
+    "@noble/hashes": 1.7.1
+  checksum: 4143f1248ed57c1ae46dfef5c692a91383e5830420b9c72d3ff1061aa9ebbf8999297da6d2aed8a9716fef8e6b1f5a45737feeab02abf55ca2a4f514bf9339ec
+  languageName: node
+  linkType: hard
+
 "@noble/hashes@npm:1.2.0, @noble/hashes@npm:~1.2.0":
   version: 1.2.0
   resolution: "@noble/hashes@npm:1.2.0"
@@ -1151,6 +1179,13 @@ __metadata:
   version: 1.4.0
   resolution: "@noble/hashes@npm:1.4.0"
   checksum: 8ba816ae26c90764b8c42493eea383716396096c5f7ba6bea559993194f49d80a73c081f315f4c367e51bd2d5891700bcdfa816b421d24ab45b41cb03e4f3342
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.7.1, @noble/hashes@npm:~1.7.1":
+  version: 1.7.1
+  resolution: "@noble/hashes@npm:1.7.1"
+  checksum: 4f1b56428a10323feef17e4f437c9093556cb18db06f94d254043fadb69c3da8475f96eb3f8322d41e8670117d7486475a8875e68265c2839f60fd03edd6a616
   languageName: node
   linkType: hard
 
@@ -1195,6 +1230,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nomicfoundation/edr-darwin-arm64@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@nomicfoundation/edr-darwin-arm64@npm:0.10.0"
+  checksum: 36fed73ecffa04931b7be27bf9b835044bf3d4ec4a65271c786416bd021e8bf44d457d5cfced5dbe1e64a83558ac861d048e2ac43807726802fc231be99d5c87
+  languageName: node
+  linkType: hard
+
 "@nomicfoundation/edr-darwin-arm64@npm:0.7.0":
   version: 0.7.0
   resolution: "@nomicfoundation/edr-darwin-arm64@npm:0.7.0"
@@ -1202,10 +1244,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-darwin-arm64@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@nomicfoundation/edr-darwin-arm64@npm:0.8.0"
-  checksum: efae7cf00c6c18e9b3854d8bf3fbb4b1e3932279f83fabb82ddfd74d623886d3cf6b00d4c437b5e81e51d16d02a5759f5a27dae25e0d64eec33422df43251d16
+"@nomicfoundation/edr-darwin-x64@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@nomicfoundation/edr-darwin-x64@npm:0.10.0"
+  checksum: 3317f2c79e90198a1387e436ca403578c70281e829f88b8535d408766e7b47c96bdb705ce2d068786ac9a44a45e5bbd90d13c6206aea36ee43e0d1b49a10f3ae
   languageName: node
   linkType: hard
 
@@ -1216,10 +1258,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-darwin-x64@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@nomicfoundation/edr-darwin-x64@npm:0.8.0"
-  checksum: fdc298850dd83e4c6e9ca42b87de112dfd38a369b4f8d7b2fbeca6e6e3f1d24879bc6e57e2362eb173525c26bd9456621c95fd4209feb1d17e3b724d8d9ed232
+"@nomicfoundation/edr-linux-arm64-gnu@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@nomicfoundation/edr-linux-arm64-gnu@npm:0.10.0"
+  checksum: 4cbbf825b53600b1089bb8d3fe25e1cf55808484d1bbd003073012471fb4d38668bdab2226d879d66d8c3d554d361d51f3a3e6ee90b708dbe28c497f30da389c
   languageName: node
   linkType: hard
 
@@ -1230,10 +1272,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-linux-arm64-gnu@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@nomicfoundation/edr-linux-arm64-gnu@npm:0.8.0"
-  checksum: f1df885d79e7887a7fb67b17e1e2337d7eba65c415942d21f1ca1118265597ba9caec409a3ff226b96a8d2facb7bfc1e1fc1338f831e793621afa25a9e3d78ad
+"@nomicfoundation/edr-linux-arm64-musl@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@nomicfoundation/edr-linux-arm64-musl@npm:0.10.0"
+  checksum: 638cb8781fbec33bb63451859e41e32c9989efdd1ba68f90f68426cda11c069ac4ffe1962520ef7d61723be05566f671e84fd35594ce2c19199cfb37d89d425f
   languageName: node
   linkType: hard
 
@@ -1244,10 +1286,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-linux-arm64-musl@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@nomicfoundation/edr-linux-arm64-musl@npm:0.8.0"
-  checksum: aa5de26be9d44b9e0e0538e1a5110aa173932cb9a21ab6c60deabe9499399f775cad02353f05ae7b8883fa59af6dd92e0f7a268fb7518736f3134a5d66d8f71c
+"@nomicfoundation/edr-linux-x64-gnu@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@nomicfoundation/edr-linux-x64-gnu@npm:0.10.0"
+  checksum: 8f46fbbadd15c52b1582349e640206004506bbe7764161bf5d7cdd47f17b3ccb11929a9946d364bc13e699a2ef5419780ece61c52515a14d47993fc446ab698b
   languageName: node
   linkType: hard
 
@@ -1258,10 +1300,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-linux-x64-gnu@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@nomicfoundation/edr-linux-x64-gnu@npm:0.8.0"
-  checksum: 0eeda6028fa923a8bd2b46ae65344e7244a4b06817fdb509349802cb80c0a81c7751d2727e71cb780474453d74e9f286807e7efc714db22205c47d3f676d6bb4
+"@nomicfoundation/edr-linux-x64-musl@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@nomicfoundation/edr-linux-x64-musl@npm:0.10.0"
+  checksum: 9d79e15ec478f66028e84c74251e2e5c675bbee286e91aa2c6d6aefc91898de7fba8ba286eae0f4592dcb74ad69193fb9a99515e99314e5e0c6b10b0c539f651
   languageName: node
   linkType: hard
 
@@ -1272,10 +1314,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-linux-x64-musl@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@nomicfoundation/edr-linux-x64-musl@npm:0.8.0"
-  checksum: 87d8d3522f36b4b6023a05c53f7d33748afb432659cafb4e255dc012613757cc3f70687693d080c65ecf8d73092534d4a00959b9d69e9d596dbce230f2e76e87
+"@nomicfoundation/edr-win32-x64-msvc@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@nomicfoundation/edr-win32-x64-msvc@npm:0.10.0"
+  checksum: 7a9214e6a8f4d9eb2df0d7c5a4fc3c32a8ac26d0a96dd2c921e31d6605dfbcd6bbdfed9cb636da027683a30accc985412e964026726d57572456434382d16557
   languageName: node
   linkType: hard
 
@@ -1286,10 +1328,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/edr-win32-x64-msvc@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@nomicfoundation/edr-win32-x64-msvc@npm:0.8.0"
-  checksum: 764dbf36654aa377d4b33e751b3cb98381f5dad1124cce0acdc4a0cbc247fe1b51f163ec3b293009937c398cce482bd492d21e00383acbc201c25380f53bb87d
+"@nomicfoundation/edr@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@nomicfoundation/edr@npm:0.10.0"
+  dependencies:
+    "@nomicfoundation/edr-darwin-arm64": 0.10.0
+    "@nomicfoundation/edr-darwin-x64": 0.10.0
+    "@nomicfoundation/edr-linux-arm64-gnu": 0.10.0
+    "@nomicfoundation/edr-linux-arm64-musl": 0.10.0
+    "@nomicfoundation/edr-linux-x64-gnu": 0.10.0
+    "@nomicfoundation/edr-linux-x64-musl": 0.10.0
+    "@nomicfoundation/edr-win32-x64-msvc": 0.10.0
+  checksum: ede23be8cb2b6a070ff75eed168d00fc63410cd33b43579bd9148d88f1d22f7b6c8d5316e6fb23efda4b07ef933fd92197ba63f28528a975d2372e2ee8d15c1a
   languageName: node
   linkType: hard
 
@@ -1305,21 +1355,6 @@ __metadata:
     "@nomicfoundation/edr-linux-x64-musl": 0.7.0
     "@nomicfoundation/edr-win32-x64-msvc": 0.7.0
   checksum: 83c54e2e2815c57ce56262f1010a0c5a2917b366bcf0acfad7662cbf2ccf46fd281e66c6db67bca9db7d91f699254216708045e882fda08c81361f111a07cb48
-  languageName: node
-  linkType: hard
-
-"@nomicfoundation/edr@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "@nomicfoundation/edr@npm:0.8.0"
-  dependencies:
-    "@nomicfoundation/edr-darwin-arm64": 0.8.0
-    "@nomicfoundation/edr-darwin-x64": 0.8.0
-    "@nomicfoundation/edr-linux-arm64-gnu": 0.8.0
-    "@nomicfoundation/edr-linux-arm64-musl": 0.8.0
-    "@nomicfoundation/edr-linux-x64-gnu": 0.8.0
-    "@nomicfoundation/edr-linux-x64-musl": 0.8.0
-    "@nomicfoundation/edr-win32-x64-msvc": 0.8.0
-  checksum: eeabb9f62174e1742d08d31904ae879c7c05de89f929980df2fa9dec5763528f3b8965bedca93fe7d1d4adb9e56c56a9dc8096992cf6f10b907d3f32f04c6676
   languageName: node
   linkType: hard
 
@@ -1827,6 +1862,13 @@ __metadata:
   version: 1.1.7
   resolution: "@scure/base@npm:1.1.7"
   checksum: d9084be9a2f27971df1684af9e40bb750e86f549345e1bb3227fb61673c0c83569c92c1cb0a4ddccb32650b39d3cd3c145603b926ba751c9bc60c27317549b20
+  languageName: node
+  linkType: hard
+
+"@scure/base@npm:~1.2.2":
+  version: 1.2.4
+  resolution: "@scure/base@npm:1.2.4"
+  checksum: db554eb550a1bd17684af9282e1ad751050a13d4add0e83ad61cc496680d7d1c1c1120ca780e72935a293bb59721c20a006a53a5eec6f6b5bdcd702cf27c8cae
   languageName: node
   linkType: hard
 
@@ -5369,7 +5411,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethereum-cryptography@npm:^2.0.0, ethereum-cryptography@npm:^2.1.2, ethereum-cryptography@npm:^2.1.3":
+"ethereum-cryptography@npm:^2.0.0, ethereum-cryptography@npm:^2.1.2, ethereum-cryptography@npm:^2.1.3, ethereum-cryptography@npm:^2.2.1":
   version: 2.2.1
   resolution: "ethereum-cryptography@npm:2.2.1"
   dependencies:
@@ -6493,16 +6535,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hardhat@npm:^2.22.19":
-  version: 2.22.19
-  resolution: "hardhat@npm:2.22.19"
+"hardhat@npm:^2.23.0":
+  version: 2.23.0
+  resolution: "hardhat@npm:2.23.0"
   dependencies:
+    "@ethereumjs/util": ^9.1.0
     "@ethersproject/abi": ^5.1.2
-    "@metamask/eth-sig-util": ^4.0.0
-    "@nomicfoundation/edr": ^0.8.0
-    "@nomicfoundation/ethereumjs-common": 4.0.4
-    "@nomicfoundation/ethereumjs-tx": 5.0.4
-    "@nomicfoundation/ethereumjs-util": 9.0.4
+    "@nomicfoundation/edr": ^0.10.0
     "@nomicfoundation/solidity-analyzer": ^0.1.0
     "@sentry/node": ^5.18.1
     "@types/bn.js": ^5.1.0
@@ -6517,7 +6556,6 @@ __metadata:
     enquirer: ^2.3.0
     env-paths: ^2.2.0
     ethereum-cryptography: ^1.0.3
-    ethereumjs-abi: ^0.6.8
     find-up: ^5.0.0
     fp-ts: 1.19.3
     fs-extra: ^7.0.1
@@ -6526,6 +6564,7 @@ __metadata:
     json-stream-stringify: ^3.1.4
     keccak: ^3.0.2
     lodash: ^4.17.11
+    micro-eth-signer: ^0.14.0
     mnemonist: ^0.38.0
     mocha: ^10.0.0
     p-map: ^4.0.0
@@ -6551,7 +6590,7 @@ __metadata:
       optional: true
   bin:
     hardhat: internal/cli/bootstrap.js
-  checksum: 08b6c1912528ed3c013d731a312836e22ad5bdbbce27a78f8dc395154548f723c6b13af90dcee71401bfd1ee910005ab252aafb44cc5e42daaee8a41e5b4c739
+  checksum: b2814cf5e996547b7a2c8f3b8bd116c34de94c3a1eca869aa5407622c8a93c1dda0b95064b004826df88594a91cbc149fba6f437af4743278790b7ffaf11acdb
   languageName: node
   linkType: hard
 
@@ -8248,10 +8287,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"micro-eth-signer@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "micro-eth-signer@npm:0.14.0"
+  dependencies:
+    "@noble/curves": ~1.8.1
+    "@noble/hashes": ~1.7.1
+    micro-packed: ~0.7.2
+  checksum: 9f49282ed8d0057c77cb65ee87a7c08909cf25ae62676c9ff8006d804bbd882dd2f56956e8589e3716ec7c647a9f308f45810c1f40416873f352a59941a17d7b
+  languageName: node
+  linkType: hard
+
 "micro-ftch@npm:^0.3.1":
   version: 0.3.1
   resolution: "micro-ftch@npm:0.3.1"
   checksum: 0e496547253a36e98a83fb00c628c53c3fb540fa5aaeaf718438873785afd193244988c09d219bb1802984ff227d04938d9571ef90fe82b48bd282262586aaff
+  languageName: node
+  linkType: hard
+
+"micro-packed@npm:~0.7.2":
+  version: 0.7.2
+  resolution: "micro-packed@npm:0.7.2"
+  dependencies:
+    "@scure/base": ~1.2.2
+  checksum: 7b9a102fe245f1902614aadf250e5d1a28caea070ad5b79fef9a449f021c5a5e2030ac3f43de7e657ec46283de0bb892a568024189064b71ecc2e9bc5efee684
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1) Perp's mint/burn fees are paid to the vault (by minting/transfering perp tokens)
2) All fees collected during flash swaps go to the vault's balance. (before it was split between perp and the vault)
3) Added owner defined drSoftBounds (similar to bill broker), which determine when flash swap fees transition from constant value to the linearly increasing fee (previously the kink point was dr=1.0).