### PR TITLE
Removed subscription ratio for a global vault:perp tvl (or system ratio)

### DIFF
--- a/spot-contracts/contracts/FeePolicy.sol
+++ b/spot-contracts/contracts/FeePolicy.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import { IFeePolicy } from "./_interfaces/IFeePolicy.sol";
-import { SubscriptionParams, Range, Line } from "./_interfaces/CommonTypes.sol";
+import { SystemState, Range, Line } from "./_interfaces/CommonTypes.sol";
 import { InvalidPerc, InvalidRange, InvalidFees } from "./_interfaces/ProtocolErrors.sol";
 
 import { LineHelpers } from "./_utils/LineHelpers.sol";
@@ -22,21 +22,21 @@ import { MathHelpers } from "./_utils/MathHelpers.sol";
  *          supports rolling over all mature collateral backing perps.
  *
  *          The system's balance is defined by it's `deviationRatio` which is defined as follows.
- *              - `subscriptionRatio`   = (vaultTVL * seniorTR) / (perpTVL * 1-seniorTR)
- *              - `deviationRatio` (dr) = subscriptionRatio / targetSubscriptionRatio
+ *              - `systemRatio`   = vaultTVL / perpTVL
+ *              - `deviationRatio` (dr) = systemRatio / targetSystemRatio
  *
  *          When the dr = 1, the system is considered perfectly balanced.
- *          When the dr < 1, it's considered "under-subscribed".
- *          When the dr > 1, it's considered "over-subscribed".
+ *          When the dr < 1, the vault is considered "under-subscribed".
+ *          When the dr > 1, the vault is  considered "over-subscribed".
  *
  *          Fees:
  *          - The system charges a greater fee for operations that move it away from the balance point.
  *          - If an operation moves the system back to the balance point, it charges a lower fee (or no fee).
  *
  *          Incentives:
- *          - When the system is "under-subscribed", value is transferred from perp to the vault at a predefined rate.
+ *          - When the vault is "under-subscribed", value is transferred from perp to the vault at a predefined rate.
  *            This debases perp tokens gradually and enriches the rollover vault.
- *          - When the system is "over-subscribed", value is transferred from the vault to perp at a predefined rate.
+ *          - When the vault is "over-subscribed", value is transferred from the vault to perp at a predefined rate.
  *            This enriches perp tokens gradually and debases the rollover vault.
  *          - This transfer is implemented through a periodic "rebalance" operation, executed by the vault, and
  *            gradually nudges the system back into balance. On rebalance, the vault queries this policy
@@ -54,10 +54,6 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
     using SafeCastUpgradeable for uint256;
     using SafeCastUpgradeable for int256;
 
-    // Replicating value used here:
-    // https://github.com/buttonwood-protocol/tranche/blob/main/contracts/BondController.sol
-    uint256 private constant TRANCHE_RATIO_GRANULARITY = 1000;
-
     /// @notice The returned fee percentages are fixed point numbers with {DECIMALS} places.
     /// @dev The decimals should line up with value expected by consumer (perp, vault).
     ///      NOTE: 10**DECIMALS => 100% or 1.0
@@ -67,10 +63,10 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
     uint256 public constant ONE = (10 ** DECIMALS);
 
     //-----------------------------------------------------------------------------
-    /// @notice The target subscription ratio i.e) the normalization factor.
-    /// @dev The ratio under which the system is considered "under-subscribed".
-    ///      Adds a safety buffer to ensure that rollovers are better sustained.
-    uint256 public targetSubscriptionRatio;
+    /// @notice The target system ratio i.e) the normalization factor.
+    /// @dev The target system ratio, the target vault tvl to perp tvl ration and
+    ///      is *different* from button-wood's tranche ratios.
+    uint256 public override targetSystemRatio;
 
     //-----------------------------------------------------------------------------
     // Fee parameters
@@ -116,7 +112,7 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
     function init() external initializer {
         __Ownable_init();
 
-        targetSubscriptionRatio = (ONE * 150) / 100; // 1.5
+        targetSystemRatio = 3 * ONE; // 3.0
 
         // initializing fees
         feeFnDRDown = Line({
@@ -151,10 +147,10 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
     //-----------------------------------------------------------------------------
     // Owner only
 
-    /// @notice Updates the target subscription ratio.
-    /// @param targetSubscriptionRatio_ The new target subscription ratio as a fixed point number with {DECIMALS} places.
-    function updateTargetSubscriptionRatio(uint256 targetSubscriptionRatio_) external onlyOwner {
-        targetSubscriptionRatio = targetSubscriptionRatio_;
+    /// @notice Updates the target system ratio.
+    /// @param targetSystemRatio_ The new target system ratio as a fixed point number with {DECIMALS} places.
+    function updateTargetSystemRatio(uint256 targetSystemRatio_) external onlyOwner {
+        targetSystemRatio = targetSystemRatio_;
     }
 
     /// @notice Updates the system fee functions.
@@ -263,7 +259,7 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
 
     /// @inheritdoc IFeePolicy
     function computeRebalanceAmount(
-        SubscriptionParams memory s
+        SystemState memory s
     ) external view override returns (int256 underlyingAmtIntoPerp) {
         // We skip rebalancing if dr is close to 1.0
         uint256 dr = computeDeviationRatio(s);
@@ -273,8 +269,7 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
         }
 
         // We compute the total value that should flow into perp to push the system into equilibrium.
-        uint256 totalTVL = s.perpTVL + s.vaultTVL;
-        uint256 reqPerpTVL = totalTVL.mulDiv(computeDRNormSeniorTR(s.seniorTR), ONE);
+        uint256 reqPerpTVL = (s.perpTVL + s.vaultTVL).mulDiv(ONE, targetSystemRatio + ONE);
         int256 reqUnderlyingAmtIntoPerp = reqPerpTVL.toInt256() - s.perpTVL.toInt256();
 
         // Perp debasement, value needs to flow from perp into the vault
@@ -308,16 +303,9 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
     }
 
     /// @inheritdoc IFeePolicy
-    function computeDeviationRatio(SubscriptionParams memory s) public view override returns (uint256) {
+    function computeDeviationRatio(SystemState memory s) public view override returns (uint256) {
         // NOTE: We assume that perp's TVL and vault's TVL values have the same base denomination.
-        uint256 juniorTR = TRANCHE_RATIO_GRANULARITY - s.seniorTR;
-        return (s.vaultTVL * s.seniorTR).mulDiv(ONE, (s.perpTVL * juniorTR)).mulDiv(ONE, targetSubscriptionRatio);
-    }
-
-    /// @inheritdoc IFeePolicy
-    function computeDRNormSeniorTR(uint256 seniorTR) public view override returns (uint256) {
-        uint256 juniorTR = (TRANCHE_RATIO_GRANULARITY - seniorTR);
-        return ONE.mulDiv((seniorTR * ONE), (seniorTR * ONE) + (juniorTR * targetSubscriptionRatio));
+        return s.vaultTVL.mulDiv(ONE, s.perpTVL).mulDiv(ONE, targetSystemRatio);
     }
 
     /// @return The range of deviation ratios which define the equilibrium zone.

--- a/spot-contracts/contracts/PerpetualTranche.sol
+++ b/spot-contracts/contracts/PerpetualTranche.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import { IERC20MetadataUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 import { IERC20Upgradeable, IPerpetualTranche, IBondIssuer, IFeePolicy, IBondController, ITranche } from "./_interfaces/IPerpetualTranche.sol";
 import { IRolloverVault } from "./_interfaces/IRolloverVault.sol";
-import { TokenAmount, RolloverData, SubscriptionParams } from "./_interfaces/CommonTypes.sol";
+import { TokenAmount, RolloverData, SystemState } from "./_interfaces/CommonTypes.sol";
 import { UnauthorizedCall, UnauthorizedTransferOut, UnexpectedDecimals, UnexpectedAsset, UnacceptableParams, UnacceptableRollover, ExceededMaxSupply, ExceededMaxMintPerTranche, ReserveCountOverLimit, InvalidPerc } from "./_interfaces/ProtocolErrors.sol";
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
@@ -642,7 +642,7 @@ contract PerpetualTranche is
 
     /// @inheritdoc IPerpetualTranche
     function deviationRatio() external override afterStateUpdate nonReentrant returns (uint256) {
-        return feePolicy.computeDeviationRatio(_querySubscriptionState());
+        return feePolicy.computeDeviationRatio(_querySystemState());
     }
 
     //--------------------------------------------------------------------------
@@ -785,14 +785,12 @@ contract PerpetualTranche is
 
         //-----------------------------------------------------------------------------
         // We charge no mint fee when interacting with other callers within the system.
-        SubscriptionParams memory s = _querySubscriptionState();
+        SystemState memory s = _querySystemState();
         uint256 feePerc = _isProtocolCaller()
             ? 0
             : feePolicy.computeFeePerc(
                 feePolicy.computeDeviationRatio(s),
-                feePolicy.computeDeviationRatio(
-                    SubscriptionParams({ perpTVL: s.perpTVL + valueIn, vaultTVL: s.vaultTVL, seniorTR: s.seniorTR })
-                )
+                feePolicy.computeDeviationRatio(SystemState({ perpTVL: s.perpTVL + valueIn, vaultTVL: s.vaultTVL }))
             );
         //-----------------------------------------------------------------------------
 
@@ -818,17 +816,13 @@ contract PerpetualTranche is
 
         //-----------------------------------------------------------------------------
         // We charge no burn fee when interacting with other parts of the system.
-        SubscriptionParams memory s = _querySubscriptionState();
+        SystemState memory s = _querySystemState();
         uint256 feePerc = _isProtocolCaller()
             ? 0
             : feePolicy.computeFeePerc(
                 feePolicy.computeDeviationRatio(s),
                 feePolicy.computeDeviationRatio(
-                    SubscriptionParams({
-                        perpTVL: s.perpTVL.mulDiv(perpSupply - perpAmt, perpSupply),
-                        vaultTVL: s.vaultTVL,
-                        seniorTR: s.seniorTR
-                    })
+                    SystemState({ perpTVL: s.perpTVL.mulDiv(perpSupply - perpAmt, perpSupply), vaultTVL: s.vaultTVL })
                 )
             );
         //-----------------------------------------------------------------------------
@@ -1051,14 +1045,9 @@ contract PerpetualTranche is
         return (trancheSupply > 0) ? trancheClaim.mulDiv(trancheAmt, trancheSupply, rounding) : trancheAmt;
     }
 
-    /// @dev Queries the current subscription state of the perp and vault systems.
-    function _querySubscriptionState() private view returns (SubscriptionParams memory) {
-        return
-            SubscriptionParams({
-                perpTVL: _reserveValue(),
-                vaultTVL: vault.getTVL(),
-                seniorTR: _depositBond.getSeniorTrancheRatio()
-            });
+    /// @dev Queries the current system state of the perp and vault systems.
+    function _querySystemState() private view returns (SystemState memory) {
+        return SystemState({ perpTVL: _reserveValue(), vaultTVL: vault.getTVL() });
     }
 
     /// @dev Checks if the given token is the underlying collateral token.

--- a/spot-contracts/contracts/PerpetualTranche.sol
+++ b/spot-contracts/contracts/PerpetualTranche.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import { IERC20MetadataUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 import { IERC20Upgradeable, IPerpetualTranche, IBondIssuer, IFeePolicy, IBondController, ITranche } from "./_interfaces/IPerpetualTranche.sol";
 import { IRolloverVault } from "./_interfaces/IRolloverVault.sol";
-import { TokenAmount, RolloverData, SystemState } from "./_interfaces/CommonTypes.sol";
+import { TokenAmount, RolloverData, SystemTVL } from "./_interfaces/CommonTypes.sol";
 import { UnauthorizedCall, UnauthorizedTransferOut, UnexpectedDecimals, UnexpectedAsset, UnacceptableParams, UnacceptableRollover, ExceededMaxSupply, ExceededMaxMintPerTranche, ReserveCountOverLimit, InvalidPerc } from "./_interfaces/ProtocolErrors.sol";
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
@@ -642,7 +642,7 @@ contract PerpetualTranche is
 
     /// @inheritdoc IPerpetualTranche
     function deviationRatio() external override afterStateUpdate nonReentrant returns (uint256) {
-        return feePolicy.computeDeviationRatio(_querySystemState());
+        return feePolicy.computeDeviationRatio(_querySystemTVL());
     }
 
     //--------------------------------------------------------------------------
@@ -785,12 +785,12 @@ contract PerpetualTranche is
 
         //-----------------------------------------------------------------------------
         // We charge no mint fee when interacting with other callers within the system.
-        SystemState memory s = _querySystemState();
+        SystemTVL memory s = _querySystemTVL();
         uint256 feePerc = _isProtocolCaller()
             ? 0
             : feePolicy.computeFeePerc(
                 feePolicy.computeDeviationRatio(s),
-                feePolicy.computeDeviationRatio(SystemState({ perpTVL: s.perpTVL + valueIn, vaultTVL: s.vaultTVL }))
+                feePolicy.computeDeviationRatio(SystemTVL({ perpTVL: s.perpTVL + valueIn, vaultTVL: s.vaultTVL }))
             );
         //-----------------------------------------------------------------------------
 
@@ -816,13 +816,13 @@ contract PerpetualTranche is
 
         //-----------------------------------------------------------------------------
         // We charge no burn fee when interacting with other parts of the system.
-        SystemState memory s = _querySystemState();
+        SystemTVL memory s = _querySystemTVL();
         uint256 feePerc = _isProtocolCaller()
             ? 0
             : feePolicy.computeFeePerc(
                 feePolicy.computeDeviationRatio(s),
                 feePolicy.computeDeviationRatio(
-                    SystemState({ perpTVL: s.perpTVL.mulDiv(perpSupply - perpAmt, perpSupply), vaultTVL: s.vaultTVL })
+                    SystemTVL({ perpTVL: s.perpTVL.mulDiv(perpSupply - perpAmt, perpSupply), vaultTVL: s.vaultTVL })
                 )
             );
         //-----------------------------------------------------------------------------
@@ -1045,9 +1045,9 @@ contract PerpetualTranche is
         return (trancheSupply > 0) ? trancheClaim.mulDiv(trancheAmt, trancheSupply, rounding) : trancheAmt;
     }
 
-    /// @dev Queries the current system state of the perp and vault systems.
-    function _querySystemState() private view returns (SystemState memory) {
-        return SystemState({ perpTVL: _reserveValue(), vaultTVL: vault.getTVL() });
+    /// @dev Queries the current TVL of the perp and vault systems.
+    function _querySystemTVL() private view returns (SystemTVL memory) {
+        return SystemTVL({ perpTVL: _reserveValue(), vaultTVL: vault.getTVL() });
     }
 
     /// @dev Checks if the given token is the underlying collateral token.

--- a/spot-contracts/contracts/_interfaces/CommonTypes.sol
+++ b/spot-contracts/contracts/_interfaces/CommonTypes.sol
@@ -10,8 +10,8 @@ struct TokenAmount {
     uint256 amount;
 }
 
-/// @notice The system state parameters.
-struct SystemState {
+/// @notice The system TVL parameters.
+struct SystemTVL {
     /// @notice The current TVL of perp denominated in the underlying.
     uint256 perpTVL;
     /// @notice The current TVL of the vault denominated in the underlying.

--- a/spot-contracts/contracts/_interfaces/CommonTypes.sol
+++ b/spot-contracts/contracts/_interfaces/CommonTypes.sol
@@ -10,14 +10,12 @@ struct TokenAmount {
     uint256 amount;
 }
 
-/// @notice The system subscription parameters.
-struct SubscriptionParams {
+/// @notice The system state parameters.
+struct SystemState {
     /// @notice The current TVL of perp denominated in the underlying.
     uint256 perpTVL;
     /// @notice The current TVL of the vault denominated in the underlying.
     uint256 vaultTVL;
-    /// @notice The tranche ratio of seniors accepted by perp.
-    uint256 seniorTR;
 }
 
 struct RolloverData {

--- a/spot-contracts/contracts/_interfaces/IFeePolicy.sol
+++ b/spot-contracts/contracts/_interfaces/IFeePolicy.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import { SystemState } from "./CommonTypes.sol";
+import { SystemTVL } from "./CommonTypes.sol";
 
 interface IFeePolicy {
     /// @return The percentage of the mint perp tokens to be charged as fees,
@@ -12,18 +12,18 @@ interface IFeePolicy {
     /// @return Number of decimals representing a multiplier of 1.0. So, 100% = 1*10**decimals.
     function decimals() external view returns (uint8);
 
-    /// @param s The subscription parameters of both the perp and vault systems.
-    /// @return The deviation ratio given the system subscription parameters.
-    function computeDeviationRatio(SystemState memory s) external view returns (uint256);
+    /// @param s The TVL of both the perp and vault systems.
+    /// @return The deviation ratio given the system TVL.
+    function computeDeviationRatio(SystemTVL memory s) external view returns (uint256);
 
     /// @return The target system ratio as a fixed-point number with {DECIMALS} decimal places.
     function targetSystemRatio() external view returns (uint256);
 
     /// @notice Computes magnitude and direction of value flow between perp and the rollover vault
     ///         expressed in underlying tokens.
-    /// @param s The subscription parameters of both the perp and vault systems.
+    /// @param s The TVL of both the perp and vault systems.
     /// @return underlyingAmtIntoPerp The value in underlying tokens, that need to flow from the vault into perp.
-    function computeRebalanceAmount(SystemState memory s) external view returns (int256 underlyingAmtIntoPerp);
+    function computeRebalanceAmount(SystemTVL memory s) external view returns (int256 underlyingAmtIntoPerp);
 
     /// @return The share of the system tvl paid to the protocol owner as fees.
     function protocolSharePerc() external view returns (uint256);

--- a/spot-contracts/contracts/_interfaces/IFeePolicy.sol
+++ b/spot-contracts/contracts/_interfaces/IFeePolicy.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import { SubscriptionParams } from "./CommonTypes.sol";
+import { SystemState } from "./CommonTypes.sol";
 
 interface IFeePolicy {
     /// @return The percentage of the mint perp tokens to be charged as fees,
@@ -14,18 +14,16 @@ interface IFeePolicy {
 
     /// @param s The subscription parameters of both the perp and vault systems.
     /// @return The deviation ratio given the system subscription parameters.
-    function computeDeviationRatio(SubscriptionParams memory s) external view returns (uint256);
+    function computeDeviationRatio(SystemState memory s) external view returns (uint256);
 
-    /// @param seniorTR The senior tranche ratio of the deposit bond.
-    /// @return The "targetSR" adjusted senior tranche ratio,
-    ///         as a fixed-point number with {DECIMALS} decimal places.
-    function computeDRNormSeniorTR(uint256 seniorTR) external view returns (uint256);
+    /// @return The target system ratio as a fixed-point number with {DECIMALS} decimal places.
+    function targetSystemRatio() external view returns (uint256);
 
     /// @notice Computes magnitude and direction of value flow between perp and the rollover vault
     ///         expressed in underlying tokens.
     /// @param s The subscription parameters of both the perp and vault systems.
     /// @return underlyingAmtIntoPerp The value in underlying tokens, that need to flow from the vault into perp.
-    function computeRebalanceAmount(SubscriptionParams memory s) external view returns (int256 underlyingAmtIntoPerp);
+    function computeRebalanceAmount(SystemState memory s) external view returns (int256 underlyingAmtIntoPerp);
 
     /// @return The share of the system tvl paid to the protocol owner as fees.
     function protocolSharePerc() external view returns (uint256);

--- a/spot-contracts/contracts/_interfaces/IRolloverVault.sol
+++ b/spot-contracts/contracts/_interfaces/IRolloverVault.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import { IVault } from "./IVault.sol";
-import { SubscriptionParams, TokenAmount } from "./CommonTypes.sol";
+import { SystemState, TokenAmount } from "./CommonTypes.sol";
 
 interface IRolloverVault is IVault {
     /// @notice Gradually transfers value between the perp and vault, to bring the system back into balance.
@@ -43,16 +43,14 @@ interface IRolloverVault is IVault {
     /// @return s The pre-swap perp and vault subscription state.
     function computeUnderlyingToPerpSwapAmt(
         uint256 underlyingAmtIn
-    ) external returns (uint256, uint256, SubscriptionParams memory);
+    ) external returns (uint256, uint256, SystemState memory);
 
     /// @notice Computes the amount of underlying tokens that are returned when user swaps a given number of perp tokens.
     /// @param perpAmtIn The number of perp tokens the user swaps in.
     /// @return underlyingAmtOut The number of underlying tokens returned to the user.
     /// @return perpFeeAmtToBurn The amount of perp tokens to be paid to the perp contract as burn fees.
     /// @return s The pre-swap perp and vault subscription state.
-    function computePerpToUnderlyingSwapAmt(
-        uint256 perpAmtIn
-    ) external returns (uint256, uint256, SubscriptionParams memory);
+    function computePerpToUnderlyingSwapAmt(uint256 perpAmtIn) external returns (uint256, uint256, SystemState memory);
 
     /// @return The system's current deviation ratio.
     function deviationRatio() external returns (uint256);

--- a/spot-contracts/contracts/_interfaces/IRolloverVault.sol
+++ b/spot-contracts/contracts/_interfaces/IRolloverVault.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import { IVault } from "./IVault.sol";
-import { SystemState, TokenAmount } from "./CommonTypes.sol";
+import { SystemTVL, TokenAmount } from "./CommonTypes.sol";
 
 interface IRolloverVault is IVault {
     /// @notice Gradually transfers value between the perp and vault, to bring the system back into balance.
@@ -40,17 +40,17 @@ interface IRolloverVault is IVault {
     /// @param underlyingAmtIn The number of underlying tokens the user swaps in.
     /// @return perpAmtOut The number of perp tokens returned to the user.
     /// @return perpFeeAmtToBurn The amount of perp tokens to be paid to the perp contract as mint fees.
-    /// @return s The pre-swap perp and vault subscription state.
+    /// @return s The pre-swap perp and vault TVL.
     function computeUnderlyingToPerpSwapAmt(
         uint256 underlyingAmtIn
-    ) external returns (uint256, uint256, SystemState memory);
+    ) external returns (uint256, uint256, SystemTVL memory);
 
     /// @notice Computes the amount of underlying tokens that are returned when user swaps a given number of perp tokens.
     /// @param perpAmtIn The number of perp tokens the user swaps in.
     /// @return underlyingAmtOut The number of underlying tokens returned to the user.
     /// @return perpFeeAmtToBurn The amount of perp tokens to be paid to the perp contract as burn fees.
-    /// @return s The pre-swap perp and vault subscription state.
-    function computePerpToUnderlyingSwapAmt(uint256 perpAmtIn) external returns (uint256, uint256, SystemState memory);
+    /// @return s The pre-swap perp and vault TVL.
+    function computePerpToUnderlyingSwapAmt(uint256 perpAmtIn) external returns (uint256, uint256, SystemTVL memory);
 
     /// @return The system's current deviation ratio.
     function deviationRatio() external returns (uint256);

--- a/spot-contracts/hardhat.config.ts
+++ b/spot-contracts/hardhat.config.ts
@@ -53,7 +53,7 @@ export default {
         settings: {
           optimizer: {
             enabled: true,
-            runs: 40,
+            runs: 50,
           },
         },
       },

--- a/spot-contracts/tasks/ops/vaults.ts
+++ b/spot-contracts/tasks/ops/vaults.ts
@@ -80,11 +80,7 @@ task("ops:vault:info")
     const subscriptionRatio = (vaultTVL * seniorTR * feeOne) / perpTVL / juniorTR;
     const targetSubscriptionRatio = await feePolicy.targetSubscriptionRatio();
     const expectedVaultTVL = (targetSubscriptionRatio * perpTVL * juniorTR) / seniorTR / feeOne;
-    const deviationRatio = await feePolicy["computeDeviationRatio((uint256,uint256,uint256))"]([
-      perpTVL,
-      vaultTVL,
-      seniorTR,
-    ]);
+    const deviationRatio = await feePolicy["computeDeviationRatio((uint256,uint256))"]([perpTVL, vaultTVL, seniorTR]);
     console.log("perpTVL:", hre.ethers.formatUnits(perpTVL, underlyingDecimals));
     console.log("vaultTVL:", hre.ethers.formatUnits(vaultTVL, underlyingDecimals));
     console.log("expectedVaultTVL:", hre.ethers.formatUnits(expectedVaultTVL, underlyingDecimals));

--- a/spot-contracts/test/RouterV2.ts
+++ b/spot-contracts/test/RouterV2.ts
@@ -49,7 +49,7 @@ describe("RouterV2", function () {
     feePolicy = new DMock(await ethers.getContractFactory("FeePolicy"));
     await feePolicy.deploy();
     await feePolicy.mockMethod("decimals()", [8]);
-    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
+    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256))", [toPercFixedPtAmt("1")]);
     await feePolicy.mockMethod("computeFeePerc(uint256,uint256)", [0]);
 
     const PerpetualTranche = await ethers.getContractFactory("PerpetualTranche");

--- a/spot-contracts/test/perp/PerpetualTranche.ts
+++ b/spot-contracts/test/perp/PerpetualTranche.ts
@@ -43,7 +43,7 @@ describe("PerpetualTranche", function () {
     feePolicy = new DMock(await ethers.getContractFactory("FeePolicy"));
     await feePolicy.deploy();
     await feePolicy.mockMethod("decimals()", [8]);
-    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
+    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256))", [toPercFixedPtAmt("1")]);
     await feePolicy.mockMethod("computeFeePerc(uint256,uint256)", [0]);
 
     const PerpetualTranche = await ethers.getContractFactory("PerpetualTranche");

--- a/spot-contracts/test/perp/PerpetualTranche_deposit.ts
+++ b/spot-contracts/test/perp/PerpetualTranche_deposit.ts
@@ -51,7 +51,7 @@ describe("PerpetualTranche", function () {
     feePolicy = new DMock(await ethers.getContractFactory("FeePolicy"));
     await feePolicy.deploy();
     await feePolicy.mockMethod("decimals()", [8]);
-    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
+    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256))", [toPercFixedPtAmt("1")]);
     await feePolicy.mockMethod("computeFeePerc(uint256,uint256)", [0]);
 
     const PerpetualTranche = await ethers.getContractFactory("PerpetualTranche");
@@ -482,15 +482,15 @@ describe("PerpetualTranche", function () {
 
     describe("when fee is set", function () {
       beforeEach(async function () {
-        await feePolicy.clearMockMethod("computeDeviationRatio((uint256,uint256,uint256))");
+        await feePolicy.clearMockMethod("computeDeviationRatio((uint256,uint256))");
         await feePolicy.mockCall(
-          "computeDeviationRatio((uint256,uint256,uint256))",
-          [[toFixedPtAmt("0"), toFixedPtAmt("0"), "500"]],
+          "computeDeviationRatio((uint256,uint256))",
+          [[toFixedPtAmt("0"), toFixedPtAmt("0")]],
           [toPercFixedPtAmt("1")],
         );
         await feePolicy.mockCall(
-          "computeDeviationRatio((uint256,uint256,uint256))",
-          [[toFixedPtAmt("500"), toFixedPtAmt("0"), "500"]],
+          "computeDeviationRatio((uint256,uint256))",
+          [[toFixedPtAmt("500"), toFixedPtAmt("0")]],
           [toPercFixedPtAmt("1")],
         );
         await feePolicy.mockMethod("computeFeePerc(uint256,uint256)", [toPercFixedPtAmt("0.01")]);

--- a/spot-contracts/test/perp/PerpetualTranche_redeem.ts
+++ b/spot-contracts/test/perp/PerpetualTranche_redeem.ts
@@ -52,7 +52,7 @@ describe("PerpetualTranche", function () {
     feePolicy = new DMock(await ethers.getContractFactory("FeePolicy"));
     await feePolicy.deploy();
     await feePolicy.mockMethod("decimals()", [8]);
-    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
+    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256))", [toPercFixedPtAmt("1")]);
     await feePolicy.mockMethod("computeFeePerc(uint256,uint256)", [0]);
 
     const PerpetualTranche = await ethers.getContractFactory("PerpetualTranche");
@@ -582,15 +582,15 @@ describe("PerpetualTranche", function () {
         );
         expect(await perp.totalSupply()).to.eq(toFixedPtAmt("1000"));
 
-        await feePolicy.clearMockMethod("computeDeviationRatio((uint256,uint256,uint256))");
+        await feePolicy.clearMockMethod("computeDeviationRatio((uint256,uint256))");
         await feePolicy.mockCall(
-          "computeDeviationRatio((uint256,uint256,uint256))",
-          [[toFixedPtAmt("1100"), toFixedPtAmt("0"), "500"]],
+          "computeDeviationRatio((uint256,uint256))",
+          [[toFixedPtAmt("1100"), toFixedPtAmt("0")]],
           [toPercFixedPtAmt("1")],
         );
         await feePolicy.mockCall(
-          "computeDeviationRatio((uint256,uint256,uint256))",
-          [[toFixedPtAmt("550"), toFixedPtAmt("0"), "500"]],
+          "computeDeviationRatio((uint256,uint256))",
+          [[toFixedPtAmt("550"), toFixedPtAmt("0")]],
           [toPercFixedPtAmt("1")],
         );
         await feePolicy.mockMethod("computeFeePerc(uint256,uint256)", [toPercFixedPtAmt("0.1")]);

--- a/spot-contracts/test/perp/PerpetualTranche_rollover.ts
+++ b/spot-contracts/test/perp/PerpetualTranche_rollover.ts
@@ -58,7 +58,7 @@ describe("PerpetualTranche", function () {
     feePolicy = new DMock(await ethers.getContractFactory("FeePolicy"));
     await feePolicy.deploy();
     await feePolicy.mockMethod("decimals()", [8]);
-    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
+    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256))", [toPercFixedPtAmt("1")]);
     await feePolicy.mockMethod("computeFeePerc(uint256,uint256)", [0]);
 
     const MockVault = await ethers.getContractFactory("MockVault");

--- a/spot-contracts/test/rollover-vault/RolloverVault.ts
+++ b/spot-contracts/test/rollover-vault/RolloverVault.ts
@@ -39,7 +39,7 @@ describe("RolloverVault", function () {
     feePolicy = new DMock(await ethers.getContractFactory("FeePolicy"));
     await feePolicy.deploy();
     await feePolicy.mockMethod("decimals()", [8]);
-    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
+    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256))", [toPercFixedPtAmt("1")]);
     await feePolicy.mockMethod("computeFeePerc(uint256,uint256)", [0]);
 
     const TrancheManager = await ethers.getContractFactory("TrancheManager");
@@ -84,7 +84,7 @@ describe("RolloverVault", function () {
     it("should set initial param values", async function () {
       expect(await vault.minDeploymentAmt()).to.eq("0");
       expect(await vault.reservedUnderlyingBal()).to.eq("0");
-      expect(await vault.reservedSubscriptionPerc()).to.eq("0");
+      expect(await vault.reservedUnderlyingPerc()).to.eq("0");
       expect(await vault.lastRebalanceTimestampSec()).not.to.eq("0");
     });
 
@@ -375,7 +375,7 @@ describe("RolloverVault", function () {
       it("should update the liquidity parameters", async function () {
         expect(await vault.minDeploymentAmt()).to.eq(toFixedPtAmt("1000"));
         expect(await vault.reservedUnderlyingBal()).to.eq(toFixedPtAmt("100000"));
-        expect(await vault.reservedSubscriptionPerc()).to.eq(toPercFixedPtAmt("0.25"));
+        expect(await vault.reservedUnderlyingPerc()).to.eq(toPercFixedPtAmt("0.25"));
       });
     });
   });

--- a/spot-contracts/test/rollover-vault/RolloverVault_deploy.ts
+++ b/spot-contracts/test/rollover-vault/RolloverVault_deploy.ts
@@ -55,7 +55,7 @@ describe("RolloverVault", function () {
     feePolicy = new DMock(await ethers.getContractFactory("FeePolicy"));
     await feePolicy.deploy();
     await feePolicy.mockMethod("decimals()", [8]);
-    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
+    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256))", [toPercFixedPtAmt("1")]);
     await feePolicy.mockMethod("computeFeePerc(uint256,uint256)", [0]);
 
     const PerpetualTranche = await ethers.getContractFactory("PerpetualTranche");

--- a/spot-contracts/test/rollover-vault/RolloverVault_deposit_redeem.ts
+++ b/spot-contracts/test/rollover-vault/RolloverVault_deposit_redeem.ts
@@ -61,7 +61,7 @@ describe("RolloverVault", function () {
     feePolicy = new DMock(await ethers.getContractFactory("FeePolicy"));
     await feePolicy.deploy();
     await feePolicy.mockMethod("decimals()", [8]);
-    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
+    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256))", [toPercFixedPtAmt("1")]);
     await feePolicy.mockMethod("computeFeePerc(uint256,uint256)", [0]);
 
     const PerpetualTranche = await ethers.getContractFactory("PerpetualTranche");
@@ -467,15 +467,15 @@ describe("RolloverVault", function () {
         await collateralToken.approve(vault.target, toFixedPtAmt("100"));
         await vault.deposit(toFixedPtAmt("100"));
 
-        await feePolicy.clearMockMethod("computeDeviationRatio((uint256,uint256,uint256))");
+        await feePolicy.clearMockMethod("computeDeviationRatio((uint256,uint256))");
         await feePolicy.mockCall(
-          "computeDeviationRatio((uint256,uint256,uint256))",
-          [[toFixedPtAmt("600"), toFixedPtAmt("100"), "200"]],
+          "computeDeviationRatio((uint256,uint256))",
+          [[toFixedPtAmt("600"), toFixedPtAmt("100")]],
           [toPercFixedPtAmt("1")],
         );
         await feePolicy.mockCall(
-          "computeDeviationRatio((uint256,uint256,uint256))",
-          [[toFixedPtAmt("600"), toFixedPtAmt("200"), "200"]],
+          "computeDeviationRatio((uint256,uint256))",
+          [[toFixedPtAmt("600"), toFixedPtAmt("200")]],
           [toPercFixedPtAmt("1")],
         );
         await feePolicy.mockMethod("computeFeePerc(uint256,uint256)", [toPercFixedPtAmt("0.05")]);
@@ -799,15 +799,15 @@ describe("RolloverVault", function () {
         await collateralToken.transfer(vault.target, toFixedPtAmt("20"));
 
         bal = toFixedPtAmt("50") * 1000000n;
-        await feePolicy.clearMockMethod("computeDeviationRatio((uint256,uint256,uint256))");
+        await feePolicy.clearMockMethod("computeDeviationRatio((uint256,uint256))");
         await feePolicy.mockCall(
-          "computeDeviationRatio((uint256,uint256,uint256))",
-          [[toFixedPtAmt("600"), toFixedPtAmt("220"), "200"]],
+          "computeDeviationRatio((uint256,uint256))",
+          [[toFixedPtAmt("600"), toFixedPtAmt("220")]],
           [toPercFixedPtAmt("1")],
         );
         await feePolicy.mockCall(
-          "computeDeviationRatio((uint256,uint256,uint256))",
-          [[toFixedPtAmt("600"), toFixedPtAmt("165"), "200"]],
+          "computeDeviationRatio((uint256,uint256))",
+          [[toFixedPtAmt("600"), toFixedPtAmt("165")]],
           [toPercFixedPtAmt("1")],
         );
         await feePolicy.mockMethod("computeFeePerc(uint256,uint256)", [toPercFixedPtAmt("0.1")]);

--- a/spot-contracts/test/rollover-vault/RolloverVault_pair_ops.ts
+++ b/spot-contracts/test/rollover-vault/RolloverVault_pair_ops.ts
@@ -53,7 +53,7 @@ describe("RolloverVault", function () {
     feePolicy = new DMock(await ethers.getContractFactory("FeePolicy"));
     await feePolicy.deploy();
     await feePolicy.mockMethod("decimals()", [8]);
-    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
+    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256))", [toPercFixedPtAmt("1")]);
     await feePolicy.mockMethod("computeFeePerc(uint256,uint256)", [0]);
 
     const PerpetualTranche = await ethers.getContractFactory("PerpetualTranche");
@@ -131,7 +131,7 @@ describe("RolloverVault", function () {
   describe("#mint2", function () {
     describe("when dr = 1", function () {
       beforeEach(async function () {
-        await feePolicy.mockMethod("computeDRNormSeniorTR(uint256)", [toPercFixedPtAmt("0.25")]);
+        await feePolicy.mockMethod("targetSystemRatio()", [toPercFixedPtAmt("3")]);
       });
 
       it("should compute amounts", async function () {
@@ -193,8 +193,8 @@ describe("RolloverVault", function () {
 
     describe("when dr > 1", function () {
       beforeEach(async function () {
-        await feePolicy.mockMethod("computeDRNormSeniorTR(uint256)", [toPercFixedPtAmt("0.25")]);
-        await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1.25")]);
+        await feePolicy.mockMethod("targetSystemRatio()", [toPercFixedPtAmt("3")]);
+        await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256))", [toPercFixedPtAmt("1.25")]);
         await vault.deposit(toFixedPtAmt("1000"));
       });
 
@@ -257,8 +257,8 @@ describe("RolloverVault", function () {
 
     describe("when dr < 1", function () {
       beforeEach(async function () {
-        await feePolicy.mockMethod("computeDRNormSeniorTR(uint256)", [toPercFixedPtAmt("0.25")]);
-        await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("0.75")]);
+        await feePolicy.mockMethod("targetSystemRatio()", [toPercFixedPtAmt("3")]);
+        await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256))", [toPercFixedPtAmt("0.75")]);
         await vault.redeem(toFixedPtAmt("500") * 1000000n);
         expect(await vault.getTVL.staticCall()).to.eq(toFixedPtAmt("1500"));
       });

--- a/spot-contracts/test/rollover-vault/RolloverVault_rebalance.ts
+++ b/spot-contracts/test/rollover-vault/RolloverVault_rebalance.ts
@@ -52,7 +52,7 @@ describe("RolloverVault", function () {
     feePolicy = new DMock(await ethers.getContractFactory("FeePolicy"));
     await feePolicy.deploy();
     await feePolicy.mockMethod("decimals()", [8]);
-    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
+    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256))", [toPercFixedPtAmt("1")]);
     await feePolicy.mockMethod("computeFeePerc(uint256,uint256)", [0]);
 
     const PerpetualTranche = await ethers.getContractFactory("PerpetualTranche");
@@ -116,7 +116,7 @@ describe("RolloverVault", function () {
     await TimeHelpers.increaseTime(86401);
 
     await feePolicy.mockMethod("protocolSharePerc()", [0n]);
-    await feePolicy.mockMethod("computeRebalanceAmount((uint256,uint256,uint256))", [0n]);
+    await feePolicy.mockMethod("computeRebalanceAmount((uint256,uint256))", [0n]);
     await feePolicy.mockMethod("protocolFeeCollector()", [await deployer.getAddress()]);
     await feePolicy.mockMethod("rebalanceFreqSec()", [86400]);
   });
@@ -151,7 +151,7 @@ describe("RolloverVault", function () {
 
     describe("no-change", function () {
       beforeEach(async function () {
-        await feePolicy.mockMethod("computeRebalanceAmount((uint256,uint256,uint256))", [toFixedPtAmt("0")]);
+        await feePolicy.mockMethod("computeRebalanceAmount((uint256,uint256))", [toFixedPtAmt("0")]);
       });
       it("should transfer value to the vault (by minting and melding perps)", async function () {
         expect(await perp.totalSupply()).to.eq(toFixedPtAmt("800"));
@@ -168,7 +168,7 @@ describe("RolloverVault", function () {
     describe("no-change with protocol fee", function () {
       beforeEach(async function () {
         await feePolicy.mockMethod("protocolSharePerc()", [toPercFixedPtAmt("0.01")]);
-        await feePolicy.mockMethod("computeRebalanceAmount((uint256,uint256,uint256))", [toFixedPtAmt("0")]);
+        await feePolicy.mockMethod("computeRebalanceAmount((uint256,uint256))", [toFixedPtAmt("0")]);
       });
       it("should transfer value to the vault (by minting and melding perps)", async function () {
         expect(await perp.totalSupply()).to.eq(toFixedPtAmt("800"));
@@ -198,7 +198,7 @@ describe("RolloverVault", function () {
 
     describe("perp debasement", function () {
       beforeEach(async function () {
-        await feePolicy.mockMethod("computeRebalanceAmount((uint256,uint256,uint256))", [toFixedPtAmt("-10")]);
+        await feePolicy.mockMethod("computeRebalanceAmount((uint256,uint256))", [toFixedPtAmt("-10")]);
       });
       it("should transfer value to the vault (by minting and melding perps)", async function () {
         expect(await perp.totalSupply()).to.eq(toFixedPtAmt("800"));
@@ -223,7 +223,7 @@ describe("RolloverVault", function () {
     describe("perp debasement with protocol fee", function () {
       beforeEach(async function () {
         await feePolicy.mockMethod("protocolSharePerc()", [toPercFixedPtAmt("0.01")]);
-        await feePolicy.mockMethod("computeRebalanceAmount((uint256,uint256,uint256))", [toFixedPtAmt("-10")]);
+        await feePolicy.mockMethod("computeRebalanceAmount((uint256,uint256))", [toFixedPtAmt("-10")]);
       });
       it("should transfer value to the vault (by minting and melding perps)", async function () {
         expect(await perp.totalSupply()).to.eq(toFixedPtAmt("800"));
@@ -262,7 +262,7 @@ describe("RolloverVault", function () {
     describe("perp enrichment", function () {
       let depositBond: Contract, depositTranches: Contract[];
       beforeEach(async function () {
-        await feePolicy.mockMethod("computeRebalanceAmount((uint256,uint256,uint256))", [toFixedPtAmt("25")]);
+        await feePolicy.mockMethod("computeRebalanceAmount((uint256,uint256))", [toFixedPtAmt("25")]);
         await perp.updateState();
         depositBond = await getDepositBond(perp);
         depositTranches = await getTranches(depositBond);
@@ -310,7 +310,7 @@ describe("RolloverVault", function () {
       let depositBond: Contract, depositTranches: Contract[];
       beforeEach(async function () {
         await feePolicy.mockMethod("protocolSharePerc()", [toPercFixedPtAmt("0.01")]);
-        await feePolicy.mockMethod("computeRebalanceAmount((uint256,uint256,uint256))", [toFixedPtAmt("25")]);
+        await feePolicy.mockMethod("computeRebalanceAmount((uint256,uint256))", [toFixedPtAmt("25")]);
         await perp.updateState();
         depositBond = await getDepositBond(perp);
         depositTranches = await getTranches(depositBond);

--- a/spot-contracts/test/rollover-vault/RolloverVault_recover.ts
+++ b/spot-contracts/test/rollover-vault/RolloverVault_recover.ts
@@ -54,7 +54,7 @@ describe("RolloverVault", function () {
     feePolicy = new DMock(await ethers.getContractFactory("FeePolicy"));
     await feePolicy.deploy();
     await feePolicy.mockMethod("decimals()", [8]);
-    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
+    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256))", [toPercFixedPtAmt("1")]);
     await feePolicy.mockMethod("computeFeePerc(uint256,uint256)", [0]);
 
     const PerpetualTranche = await ethers.getContractFactory("PerpetualTranche");

--- a/spot-contracts/test/rollover-vault/RolloverVault_swap.ts
+++ b/spot-contracts/test/rollover-vault/RolloverVault_swap.ts
@@ -55,7 +55,7 @@ describe("RolloverVault", function () {
     feePolicy = new DMock(await ethers.getContractFactory("FeePolicy"));
     await feePolicy.deploy();
     await feePolicy.mockMethod("decimals()", [8]);
-    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256,uint256))", [toPercFixedPtAmt("1")]);
+    await feePolicy.mockMethod("computeDeviationRatio((uint256,uint256))", [toPercFixedPtAmt("1")]);
     await feePolicy.mockMethod("computeFeePerc(uint256,uint256)", [0]);
 
     const PerpetualTranche = await ethers.getContractFactory("PerpetualTranche");
@@ -138,7 +138,6 @@ describe("RolloverVault", function () {
           expect(s[1]).to.eq(0);
           expect(s[2].perpTVL).to.eq(toFixedPtAmt("800"));
           expect(s[2].vaultTVL).to.eq(toFixedPtAmt("2000"));
-          expect(s[2].seniorTR).to.eq("200");
         });
 
         it("should update vault after swap", async function () {
@@ -169,7 +168,6 @@ describe("RolloverVault", function () {
           expect(s[1]).to.eq(0);
           expect(s[2].perpTVL).to.eq(toFixedPtAmt("1600"));
           expect(s[2].vaultTVL).to.eq(toFixedPtAmt("2000"));
-          expect(s[2].seniorTR).to.eq("200");
         });
 
         it("should update vault after swap", async function () {
@@ -199,7 +197,6 @@ describe("RolloverVault", function () {
           expect(s[1]).to.eq(0);
           expect(s[2].perpTVL).to.eq(toFixedPtAmt("400"));
           expect(s[2].vaultTVL).to.eq(toFixedPtAmt("120"));
-          expect(s[2].seniorTR).to.eq("200");
         });
         it("should update vault after swap", async function () {
           await checkVaultComposition(
@@ -229,7 +226,6 @@ describe("RolloverVault", function () {
           expect(s[1]).to.eq(0);
           expect(s[2].perpTVL).to.eq(toFixedPtAmt("800"));
           expect(s[2].vaultTVL).to.eq(toFixedPtAmt("1780"));
-          expect(s[2].seniorTR).to.eq("200");
         });
 
         it("should update vault after swap", async function () {
@@ -260,7 +256,6 @@ describe("RolloverVault", function () {
           expect(s[1]).to.eq(0);
           expect(s[2].perpTVL).to.eq(toFixedPtAmt("800"));
           expect(s[2].vaultTVL).to.eq(toFixedPtAmt("2220"));
-          expect(s[2].seniorTR).to.eq("200");
         });
 
         it("should update vault after swap", async function () {
@@ -292,7 +287,6 @@ describe("RolloverVault", function () {
         expect(s[1]).to.eq(toFixedPtAmt("0"));
         expect(s[2].perpTVL).to.eq(toFixedPtAmt("800"));
         expect(s[2].vaultTVL).to.eq(toFixedPtAmt("2000"));
-        expect(s[2].seniorTR).to.eq("200");
       });
     });
 
@@ -317,7 +311,7 @@ describe("RolloverVault", function () {
 
     describe("when percentage of liquidity is too low", function () {
       beforeEach(async function () {
-        await vault.updateLiquidityLimits(toFixedPtAmt("2500"), toFixedPtAmt("0"), toPercFixedPtAmt("0.25"));
+        await vault.updateLiquidityLimits(toFixedPtAmt("2500"), toFixedPtAmt("0"), toPercFixedPtAmt("0.4"));
       });
       it("should be reverted", async function () {
         await expect(vault.swapUnderlyingForPerps(toFixedPtAmt("100"))).to.be.revertedWithCustomError(
@@ -609,7 +603,6 @@ describe("RolloverVault", function () {
           expect(s[1]).to.eq(0);
           expect(s[2].perpTVL).to.eq(toFixedPtAmt("800"));
           expect(s[2].vaultTVL).to.eq(toFixedPtAmt("2000"));
-          expect(s[2].seniorTR).to.eq("200");
         });
       });
 
@@ -623,7 +616,6 @@ describe("RolloverVault", function () {
           expect(s[1]).to.eq(0);
           expect(s[2].perpTVL).to.eq(toFixedPtAmt("1600"));
           expect(s[2].vaultTVL).to.eq(toFixedPtAmt("2000"));
-          expect(s[2].seniorTR).to.eq("200");
         });
       });
 
@@ -637,7 +629,6 @@ describe("RolloverVault", function () {
           expect(s[1]).to.eq(0);
           expect(s[2].perpTVL).to.eq(toFixedPtAmt("400"));
           expect(s[2].vaultTVL).to.eq(toFixedPtAmt("120"));
-          expect(s[2].seniorTR).to.eq("200");
         });
       });
     });
@@ -653,7 +644,6 @@ describe("RolloverVault", function () {
         expect(s[1]).to.eq(toFixedPtAmt("0"));
         expect(s[2].perpTVL).to.eq(toFixedPtAmt("800"));
         expect(s[2].vaultTVL).to.eq(toFixedPtAmt("2000"));
-        expect(s[2].seniorTR).to.eq("200");
       });
     });
 


### PR DESCRIPTION
Now the spot system doesn't care about the bond ratios used by the underlying tranches. It balances incentives and fees based on an owner defined vaultTVL : perpTVL target ratio (or system ratio)