### PR TITLE
Fee update

### DIFF
--- a/spot-contracts/contracts/FeePolicy.sol
+++ b/spot-contracts/contracts/FeePolicy.sol
@@ -175,9 +175,6 @@ contract FeePolicy is IFeePolicy, OwnableUpgradeable {
         // Expect DR to be non-decreasing, x1 <= x2
         bool validFees = ((feeFnDRDown_.x1 <= feeFnDRDown_.x2) && (feeFnDRUp_.x1 <= feeFnDRUp_.x2));
 
-        // Expect equilibrium zone to be valid
-        validFees = ((feeFnDRDown_.x2 <= ONE) && (feeFnDRUp_.x1 >= ONE)) && validFees;
-
         // Expect fees to be non-decreasing when dr moves away from 1.0
         validFees = ((feeFnDRDown_.y1 >= feeFnDRDown_.y2) && (feeFnDRUp_.y1 <= feeFnDRUp_.y2)) && validFees;
 

--- a/spot-contracts/test/FeePolicy.ts
+++ b/spot-contracts/test/FeePolicy.ts
@@ -148,20 +148,6 @@ describe("FeePolicy", function () {
         );
       });
 
-      it("equilibrium zone crosses 1.0", async function () {
-        const badDown = toLine("0.0", "1.0", "1.1", "0.0");
-        await expect(feePolicy.connect(deployer).updateFees(badDown, VALID_UP)).to.be.revertedWithCustomError(
-          feePolicy,
-          "InvalidFees",
-        );
-
-        const badUp = toLine("0.9", "0.0", "2.0", "1.0");
-        await expect(feePolicy.connect(deployer).updateFees(VALID_DOWN, badUp)).to.be.revertedWithCustomError(
-          feePolicy,
-          "InvalidFees",
-        );
-      });
-
       it("fees not monotonic wrt distance from 1.0", async function () {
         const badDown = toLine("0.0", "0.0", "1.0", "1.0");
         await expect(feePolicy.connect(deployer).updateFees(badDown, VALID_UP)).to.be.revertedWithCustomError(


### PR DESCRIPTION
If we think the fees act as brakes, then we should be able to start applying the fees before the system gets out of balance.

So for example, when dr > 1; and dr is decreasing we can start applying fees at 1.05 (ie before we get to 1). Similarly when dr < 1 and dr is increasing, we can start applying fees at 0.95 rather than wait till we get to 1. 